### PR TITLE
docs(openspec): plan hero-liquid-glass-redesign

### DIFF
--- a/openspec/changes/hero-liquid-glass-redesign/design.md
+++ b/openspec/changes/hero-liquid-glass-redesign/design.md
@@ -1,0 +1,461 @@
+# Design: hero-liquid-glass-redesign
+
+> Architecture phase. This document closes the HOW at structural level. Tasks (the WHAT-to-do steps) come next.
+> Every external API claim that would normally require Context7 verification is marked **[CTX7-DEFERRED]** with the assumption it forces and the mitigation if it turns out wrong. See §13.
+
+---
+
+## 1. Architecture Overview
+
+Three concentric layers, each with a single responsibility and a strict boundary:
+
+```
+┌────────────────────────── RSC LAYER (server) ─────────────────────────────┐
+│ HeroSection.tsx                                                           │
+│   <section aria-labelledby="hero-title">                                  │
+│     <p class="eyebrow">{t.eyebrow}</p>                                    │
+│     <h1 id="hero-title">Héctor Trejo Luna — Senior Software Architect</h1>│
+│     <p class="lead">{profile.headline ?? t.lead}</p>                      │
+│     <a class="cta-primary">{t.cta}</a>                                    │
+│     <a class="cta-secondary">{t.secondaryLabel}</a>                       │
+│     <HeroVisualLayer profile={...} flagOn={...}/>   ← single client entry │
+│   </section>                                                              │
+│   ▶ Zero JS shipped for the text. h1 is the LCP candidate.                │
+└────────────────────────────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+┌─────────────────────── CLIENT BOUNDARY (eager) ───────────────────────────┐
+│ HeroVisualLayer.tsx  ("use client")                                       │
+│   • Calls useHeroMotionPreferences() ONCE                                 │
+│   • Branches: "static" → render nothing visual                            │
+│                "css-only" → <LiquidGlassBackdrop/>                        │
+│                "css+webgl" → <LiquidGlassBackdrop/> + <LiquidGlassWebGL/> │
+│   • Owns the section ref forwarded to useScroll + IntersectionObserver    │
+│   • Mounts the cursor controller (singleton ref store)                    │
+└────────────────────────────────────────────────────────────────────────────┘
+                  │                                  │
+                  ▼                                  ▼
+┌─────────────────────────┐         ┌──────────────────────────────────────┐
+│ LiquidGlassBackdrop     │         │ LiquidGlassWebGL                     │
+│ "use client", aria-hidden│        │ next/dynamic({ ssr: false })          │
+│ • SVG goo <defs>        │         │ aria-hidden                          │
+│ • 3 animated blobs      │         │ • <Canvas dpr=[1,1.5] frameloop=demand>│
+│ • backdrop-filter card  │         │   <Plane><MeshTransmissionMaterial/> │
+│ • reads --mx/--my CSS   │         │ • useFrame reads ref store directly  │
+│   vars                  │         │ • uniforms: uTime,uMx,uMy,uScroll,   │
+│                         │         │   uBurst                             │
+└─────────────────────────┘         └──────────────────────────────────────┘
+                  ▲                                  ▲
+                  └────────── pointer ref store ─────┘
+                              (single rAF source)
+```
+
+**Boundary rules**:
+- The RSC layer never imports anything from `react-three/*` or `framer-motion` (those have `"use client"` somewhere in their tree and would taint the RSC).
+- `HeroVisualLayer` is the **only** client island the RSC renders. All client-only logic descends from it. This keeps the RSC tree analyzable and the bundle attribution clean.
+- The WebGL chunk is only fetched after `HeroVisualLayer` decides the profile is `"css+webgl"` AND the section is in viewport (IntersectionObserver `threshold: 0.1`) AND `requestIdleCallback` fires. Three gates, in this order.
+
+---
+
+## 2. Component Tree (final)
+
+```
+HeroSection.tsx                     [RSC, server-only]
+└── HeroVisualLayer.tsx             [client, eager]
+    ├── LiquidGlassBackdrop.tsx     [client, eager, "use client"]
+    │   ├── <svg><defs><filter id="liquid-goo">…</filter></defs></svg>
+    │   ├── .blob.blob-1
+    │   ├── .blob.blob-2
+    │   ├── .blob.blob-3
+    │   └── .glass-card-overlay     (backdrop-filter; sits behind RSC text via z-index)
+    └── LiquidGlassWebGL.tsx        [next/dynamic ssr:false, lazy]
+        └── <Canvas>
+            └── <Plane>
+                └── <MeshTransmissionMaterial
+                       transmission={1}
+                       thickness={1.5}
+                       ior={1.4}
+                       chromaticAberration={0.05}
+                       distortion={…}
+                       distortionScale={…}
+                       temporalDistortion={…}
+                       samples={6}
+                       resolution={256}
+                       backside
+                     />
+```
+
+**Why a `HeroVisualLayer` wrapper instead of mounting the two children directly from the RSC?**
+Next.js + RSC: a Server Component CAN import a `next/dynamic({ ssr: false })` component, but the call to `next/dynamic` itself is a client-only API in Next 16's evolving model **[CTX7-DEFERRED §13.1]**. Wrapping in a single `"use client"` boundary is the bulletproof approach: the Server Component imports `HeroVisualLayer` (a client component), and `dynamic` is invoked inside that client boundary. This is also how we co-locate the capability gate — it MUST run in the browser.
+
+---
+
+## 3. Data & Control Flow
+
+### 3.1 Cursor → uniforms (zero React re-renders)
+
+```
+section.addEventListener("pointermove", onMove, { passive: true })
+            │
+            ▼
+   rAF-throttled handler   (in HeroVisualLayer)
+            │
+            ├─→ section.style.setProperty("--mx", `${nx * 100}%`)
+            │   section.style.setProperty("--my", `${ny * 100}%`)
+            │   (consumed by LiquidGlassBackdrop blobs)
+            │
+            └─→ pointerStore.set({ x: nx, y: ny })
+                (singleton in packages/ui/src/state/heroPointerStore.ts)
+                            │
+                            ▼
+                useFrame in LiquidGlassWebGL reads pointerStore.value
+                and writes material.uniforms.uMx.value / uMy.value
+```
+
+**Why a singleton ref store and not React state?**
+`pointermove` fires up to 60×/sec. Going through React state would re-render the entire WebGL subtree at 60 Hz, defeating the demand frameloop. The singleton is a `{ value: {x, y}, set, subscribe }` triplet. `useFrame` reads `pointerStore.value` directly each frame — no subscription needed because r3f's `useFrame` already runs every frame the renderer ticks.
+
+`useSyncExternalStore` is reserved for any React-tree consumers that ever need the value (none planned — kept as escape hatch).
+
+### 3.2 Scroll → uScroll uniform
+
+```
+const heroRef = useRef<HTMLElement>(null);
+const { scrollYProgress } = useScroll({
+  target: heroRef,
+  offset: ["start start", "end start"],   // [CTX7-DEFERRED §13.3]
+});
+const uScroll = useTransform(scrollYProgress, [0, 1], [0, 0.6]);
+```
+
+`uScroll` is a MotionValue. We DO NOT subscribe with `useMotionValueEvent` (which would re-render). Instead, inside `LiquidGlassWebGL`'s `useFrame`, we call `uScroll.get()` and write to `material.uniforms.uScroll.value`. Reduced-motion path clamps the transform output to `[0, 0]`.
+
+### 3.3 Burst → uBurst tween (one-shot, mount-time)
+
+```
+useEffect(() => {
+  if (profile !== "css+webgl") return;
+  const start = performance.now();
+  const duration = 1200;        // ms, locked
+  let raf = 0;
+  const tick = (now: number) => {
+    const t = Math.min(1, (now - start) / duration);
+    // ease: 0 → 1 → 0 over the 1200ms window
+    const eased = t < 0.5 ? easeOutCubic(t * 2) : 1 - easeInCubic((t - 0.5) * 2);
+    burstStore.set(eased);
+    if (t < 1) raf = requestAnimationFrame(tick);
+  };
+  raf = requestAnimationFrame(tick);
+  return () => cancelAnimationFrame(raf);
+}, [profile]);
+```
+
+`burstStore` is another singleton; `useFrame` reads it. After the 1200ms window, `uBurst` stays at 0 forever for that page load. No replay on re-render.
+
+### 3.4 The motion-preferences hook (single source of truth)
+
+```ts
+// packages/ui/src/hooks/useHeroMotionPreferences.ts
+type HeroProfile = "static" | "css-only" | "css+webgl";
+
+interface HeroMotionPreferences {
+  profile: HeroProfile;
+  ready: boolean;            // false until the first capability check resolves
+}
+
+export function useHeroMotionPreferences(): HeroMotionPreferences;
+```
+
+Discriminated union, not a soup of booleans. Every consumer branches on `profile`. `ready=false` during SSR + first paint guarantees no client-only DOM until hydration finishes (avoids hydration mismatch).
+
+---
+
+## 4. Capability Gate (formal)
+
+```ts
+function detectProfile(): HeroProfile {
+  // SSR-safe early return
+  if (typeof window === "undefined") return "static";
+
+  // Highest priority: user preference
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (reduced) return "static";
+
+  // Hard floors for WebGL
+  const desktop      = window.matchMedia("(min-width: 1024px)").matches;
+  const concurrency  = (navigator.hardwareConcurrency ?? 0) >= 4;
+  const saveData     = (navigator as any).connection?.saveData === true;
+  const webgl2       = (() => {
+    try {
+      const c = document.createElement("canvas");
+      return !!c.getContext("webgl2");
+    } catch { return false; }
+  })();
+  // Feature flag is the final OR-gate
+  const flagOn = process.env.NEXT_PUBLIC_HERO_LIQUID === "true";
+
+  if (!flagOn) return "static"; // legacy hero owns the page when flag is off
+  if (!desktop || !concurrency || saveData || !webgl2) return "css-only";
+  return "css+webgl";
+}
+```
+
+| Check | Threshold | Why this number |
+|-------|-----------|-----------------|
+| `prefers-reduced-motion` | `reduce` → static | WCAG 2.3.3 (Animation from Interactions). Non-negotiable. |
+| Viewport width | ≥ 1024px | Tablets and phones throttle GPU thermally; the splash blows fans. 1024 matches our `lg` breakpoint. |
+| `hardwareConcurrency` | ≥ 4 cores | Filters single/dual-core ARM Chromebooks and budget Android. Empirical floor for 60fps `MeshTransmissionMaterial`. |
+| `saveData` | not true | Honors NetInfo Save-Data hint. Cheap chunk respect. |
+| WebGL2 | available | drei `MeshTransmissionMaterial` requires WebGL2-class precision (mediump float on mobile WebGL1 produces banding). [CTX7-DEFERRED §13.2] |
+| Feature flag | `true` | Kill switch. False → static profile → legacy hero (Phase 1). |
+
+**Where each check runs**: 100% client-side. The hook returns `{ profile: "static", ready: false }` until the first `useEffect` runs post-hydration; only then does it commit the real profile via `setState`. This is the SSR-safe pattern.
+
+---
+
+## 5. Bundle Strategy
+
+### 5.1 Layout
+
+| Chunk | Contents | Size budget |
+|-------|----------|-------------|
+| `app/[locale]/page` (initial) | RSC HeroSection HTML + HeroVisualLayer client island + LiquidGlassBackdrop | **+5 KB gz** delta vs. baseline |
+| `chunks/hero-webgl-[hash].js` (lazy) | three core, drei `MeshTransmissionMaterial`, LiquidGlassWebGL component | **≤ 200 KB gz** hard cap |
+
+### 5.2 Tree-shaking drei
+
+`@react-three/drei` ships ~150+ helpers. We import ONLY what we use:
+
+```ts
+// Preferred: subpath import to shake aggressively
+import { MeshTransmissionMaterial } from "@react-three/drei/core/MeshTransmissionMaterial";
+// [CTX7-DEFERRED §13.2] — verify this subpath exists in installed drei version.
+// If not, fall back to: import { MeshTransmissionMaterial } from "@react-three/drei"
+// and rely on Webpack/Turbopack tree-shaking + sideEffects:false in drei's package.json.
+```
+
+We also import `extend` from `@react-three/fiber` only if needed for `<Plane>` substitute (probably use a literal `<mesh><planeGeometry/>…</mesh>` to avoid the helper).
+
+### 5.3 Enforcement
+
+A new script `scripts/check-bundle-size.mjs` runs in `qa:gate`:
+
+```js
+// Reads .next/build-manifest.json + .next/server/pages-manifest.json
+// Finds the chunk whose name matches /hero-webgl/, gzips its contents in-memory,
+// asserts <= 200 * 1024.
+// Also asserts the page's initial bundle delta vs. a stored baseline (.bundle-baseline.json).
+```
+
+`size-limit` is the canonical tool but adding it pulls a config + dep. The custom script is ~80 LOC, no new deps, and reads Turbopack's manifests directly.
+
+### 5.4 Compatibility verification (must run before tasks)
+
+| Lib | Version | Concern | [CTX7] |
+|-----|---------|---------|--------|
+| `@react-three/fiber` | latest v9 expected | React 19 root API, Next 16 Turbopack | §13.1 |
+| `@react-three/drei` | latest | `MeshTransmissionMaterial` props stable | §13.2 |
+| `framer-motion` | 12.38.0 (installed) | `useScroll({target,offset})` signature | §13.3 |
+| `next-intl` | 4.9.1 (installed) | `useTranslations` in async RSC | §13.4 |
+| `next` | latest (16) | `dynamic({ssr:false})` boundary rules | §13.1 |
+
+---
+
+## 6. SSR / Hydration Discipline
+
+| Element | Rendered | First paint | Hydration trigger |
+|---------|----------|-------------|-------------------|
+| `<h1>`, eyebrow, lead, CTAs | RSC HTML | yes (LCP candidate) | n/a — pure HTML |
+| `<HeroVisualLayer>` mount | client | no (placeholder = empty `<div aria-hidden>`) | post-hydration |
+| `LiquidGlassBackdrop` blobs | client, CSS only | no | mounts when `profile !== "static" && ready` |
+| CSS vars `--mx`, `--my` | NOT set during SSR | static defaults from CSS rule | initialized in `useEffect` |
+| WebGL `<Canvas>` | client, dynamic | no | mounts when `profile === "css+webgl"` AND in viewport AND idle |
+
+**Hydration-mismatch defenses**:
+1. `HeroVisualLayer` returns `null` until `ready === true`. SSR HTML and first client render match (both empty).
+2. CSS declares default `--mx: 50%; --my: 50%;` on the section. JS only ever writes new values — never reads them during SSR.
+3. The `<svg>` goo `<defs>` is rendered server-side as static markup (no `id` collisions because it's namespaced `liquid-goo-{instance}` if multiple instances ever exist; in practice we use a single instance).
+
+**Next 16 RSC + dynamic({ssr:false})**: by sandwiching the dynamic call inside `HeroVisualLayer` (`"use client"`), we sidestep any RSC-vs-dynamic edge case. The Server Component only sees a regular client component import. **[CTX7-DEFERRED §13.1]**
+
+---
+
+## 7. Reduced-Motion Story
+
+`profile === "static"` activates the following transformation:
+
+| Layer | static behavior |
+|-------|-----------------|
+| Blob CSS animations | `animation-play-state: paused`; blobs render frozen at their `--mx:50%, --my:50%` defaults |
+| Cursor listener | NOT attached (the rAF loop never starts) |
+| SVG goo filter | Applied as static distortion — `<feTurbulence>` evaluates once at mount, then no `<animate>` element drives it |
+| Scroll → distortion | `useScroll` not consumed; no MotionValue subscription |
+| WebGL | Never imported |
+| Sheen sweep | `animation-play-state: paused` |
+
+The visual identity is preserved (frozen liquid-glass card, gradient, h1) — accessibility users get a premium static composition, not a downgraded blank section. **No fallback image needed**: the CSS layer self-renders.
+
+A `prefers-color-scheme: dark` media query is independent and applies always.
+
+---
+
+## 8. SEO Story
+
+| Asset | Source | Location |
+|-------|--------|----------|
+| Single `<h1>` | i18n: `hero.h1Name` + " — " + `hero.h1Role` | RSC HTML, in initial response |
+| `aria-labelledby="hero-title"` | static | `<section>` element |
+| Lead paragraph | `profile?.headline ?? t("hero.lead")` | RSC HTML |
+| JSON-LD `Person` | `app/[locale]/page.tsx`, extended with `image` (Sanity CDN URL) + `mainEntityOfPage` | `<head>` via `<script type="application/ld+json">` |
+| OG image | existing `app/[locale]/layout.tsx` `Metadata` | unchanged unless missing |
+| Locale alternates | Next.js i18n routing already emits `hreflang` | unchanged |
+
+**`useTranslations` in Server Component**: next-intl 4.9 supports `useTranslations` in async Server Components since 4.0. **[CTX7-DEFERRED §13.4]**. If the installed version requires `getTranslations({ locale })` instead, we switch — both work identically for our use case (scoped `"hero"` namespace, no formatting).
+
+**LCP target**: the `<h1>` is the Largest Contentful Paint candidate because (a) it's text in initial HTML, (b) it sits in the viewport, (c) the WebGL canvas mounts later and is smaller in painted area than the h1 box (the canvas covers the section but most of its painted pixels are translucent; LCP measures contentful paint, and translucent layers don't displace the h1 candidate). Verified empirically in verify phase via `PerformanceObserver({ type: "largest-contentful-paint" })`.
+
+---
+
+## 9. Test Strategy (TDD)
+
+> Strict TDD is enabled for this project. Every component below ships with its test written FIRST.
+
+### 9.1 Vitest unit tests (jsdom)
+
+| Test file | What it asserts |
+|-----------|-----------------|
+| `HeroSection.test.tsx` | Renders exactly one `<h1>`. Renders eyebrow, lead, primary CTA, secondary CTA. `aria-labelledby` matches h1 `id`. JSON-LD-irrelevant — that lives in the page test. |
+| `HeroVisualLayer.test.tsx` | Returns `null` while `ready=false`. After ready, renders `<LiquidGlassBackdrop>` for `css-only` and `css+webgl`, nothing for `static`. Renders the `next/dynamic` placeholder for the WebGL chunk only when `css+webgl`. |
+| `useHeroMotionPreferences.test.ts` | Mocks `matchMedia` + `navigator.hardwareConcurrency` + `navigator.connection.saveData` + `WebGL2RenderingContext`. Asserts every cell of the truth table (8 combinations covering each gate flipping). |
+| `LiquidGlassBackdrop.test.tsx` | Attaches `pointermove` on mount, detaches on unmount. Sets `--mx`/`--my` only inside `useEffect`. Honors a passed `profile="static"` prop by not attaching. |
+| `useLiquidPointer.test.ts` | rAF throttling: 100 synchetic moves in one frame collapse to one DOM write. |
+| `heroPointerStore.test.ts` | Singleton across imports; `set`/`subscribe`/`value` semantics. |
+
+### 9.2 Vitest integration
+
+| Test | Assertion |
+|------|-----------|
+| `HeroSection.integration.test.tsx` | Reduced-motion path: render with `matchMedia` mock returning reduced; expect NO `<canvas>` in DOM, no `pointermove` listener attached, blobs paused. |
+| `HeroSection.flag-off.test.tsx` | `NEXT_PUBLIC_HERO_LIQUID=false` → renders nothing extra; legacy `HeroFragment` is the chosen render in `ObsidianStream`. |
+
+### 9.3 Playwright e2e
+
+| Project (browser × viewport) | Assertion |
+|------------------------------|-----------|
+| chromium-desktop (1440×900) | `<canvas>` element appears within 5s of section intersection; `expect(page.locator("canvas")).toBeVisible()`. |
+| chromium-mobile (375×812) | `expect(page.locator("canvas")).toHaveCount(0)` — capability gate excludes mobile. |
+| chromium-reduced-motion (`reducedMotion: 'reduce'`) | No canvas; blobs do not animate (verify via computed style `animation-play-state`). |
+| axe-a11y | 0 violations on the hero section. `expect(page.locator("h1")).toHaveCount(1)`. |
+| contrast | Screenshot the h1 region; pixel-sample assertion that effective text-vs-background ratio ≥ 4.5:1 WCAG AA. |
+| LCP | `await page.evaluate(() => new Promise(r => new PerformanceObserver((l) => r(l.getEntries().pop().element.tagName)).observe({type:'largest-contentful-paint',buffered:true})))` returns `"H1"`. |
+
+### 9.4 Lighthouse CI
+
+```js
+// lighthouserc.cjs additions
+{
+  assertions: {
+    "categories:performance": ["error", { minScore: 0.90 }],
+    "categories:seo":         ["error", { minScore: 0.95 }],
+    "categories:accessibility": ["error", { minScore: 0.95 }],
+    "largest-contentful-paint": ["error", { maxNumericValue: 2500 }],
+    "total-blocking-time": ["warn", { maxNumericValue: 200 }],
+  }
+}
+```
+
+Mobile profile uses `minScore: 0.85` for performance, the rest unchanged.
+
+### 9.5 Storybook
+
+Stories under `apps/portfolio/components/fragments/HeroSection.stories.tsx`:
+- `Default` — `profile="css+webgl"`, flag on, full hero.
+- `ReducedMotion` — overrides `matchMedia` to return reduced.
+- `NoWebGL` — forces `profile="css-only"` via decorator.
+- `Hover` — uses `play` function to move pointer; visual regression target.
+- `Scroll` — wraps the story in a 200vh container; scrolls the canvas into distortion mode.
+- `FlagOff` — verifies legacy hero appears; smoke test only.
+
+---
+
+## 10. Migration Plan
+
+| Phase | Action | Done when |
+|-------|--------|-----------|
+| 0 (setup) | Add deps `@react-three/fiber`, `@react-three/drei`, `three`. Add `NEXT_PUBLIC_HERO_LIQUID=false` to `.env.example`. Verify Context7 lookups (§13). | `pnpm install` clean, type-check passes. |
+| 1 (build) | Implement components TDD-first behind flag (default false). Land tests + storybook + e2e + lighthouse baseline in PR. `ObsidianStream` reads the flag and chooses between `HeroFragment` and `HeroSection`. | All 9.x tests green. PR merged with flag off. |
+| 2 (preview) | Set `NEXT_PUBLIC_HERO_LIQUID=true` in Vercel preview. QA team validates. Lighthouse comparison vs. baseline. RUM for 48h. | LCP, INP, CLS within budget; SEO ≥ 95. |
+| 3 (production) | Flip flag in production. Monitor Web Vitals 7-14 days. | No regression alarms; engagement metrics stable or up. |
+| 4 (cleanup) | Delete `HeroFragment.tsx`, its tests, the legacy i18n keys, and the flag check in `ObsidianStream`. Single small PR. | Repo no longer references `HeroFragment`. |
+
+Rollback at any phase: set flag false → next deploy → legacy hero. No code change.
+
+---
+
+## 11. Open Decisions for sdd-tasks
+
+| # | Decision | Recommendation |
+|---|----------|----------------|
+| 1 | Final h1 wording | **`Héctor Trejo Luna — Senior Software Architect`** (en) / **`Héctor Trejo Luna — Arquitecto Senior de Software`** (es). Locked here unless tasks finds copy conflict. |
+| 2 | Eyebrow microcopy | en: `"Building digital experiences"` ; es: `"Construyendo experiencias digitales"`. Tasks phase confirms with current site voice. |
+| 3 | OG / JSON-LD `image` | Use existing Sanity profile avatar via `urlForImage(profile.avatar).width(1200).height(630).url()`. If absent, fall back to `/og-default.png` static asset. Tasks verifies asset exists. |
+| 4 | Extract `LiquidGlassBackdrop` to `packages/ui` immediately or defer | **Extract immediately**. Proposal already places it in `packages/ui`. Cost is one re-export; benefit is reusability for future hero variants. |
+| 5 | Deprecate legacy i18n keys (`hero.titleLine1`, `titleLine2`, `headline`, `subheadline`) | Keep through Phase 1, delete in Phase 4. Tasks adds a comment marker. |
+| 6 | drei subpath import works? | Tasks verifies via Context7 + a build smoke-test before locking. Fallback documented in §5.2. |
+
+---
+
+## 12. Mermaid sequence diagram (paint timeline)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Browser
+  participant Server as Next.js Server
+  participant Hyd as Client Hydration
+  participant Lazy as WebGL Chunk
+
+  Browser->>Server: GET /en
+  Server-->>Browser: SSR HTML (h1, lead, CTAs, JSON-LD in <head>)
+  Note over Browser: First paint — h1 = LCP candidate
+  Browser->>Hyd: hydrate HeroVisualLayer
+  Hyd->>Hyd: useHeroMotionPreferences runs in useEffect
+  alt profile === "static"
+    Note over Hyd: Render nothing visual; legacy or frozen layer
+  else profile === "css-only"
+    Hyd->>Hyd: Mount LiquidGlassBackdrop, attach pointermove
+  else profile === "css+webgl"
+    Hyd->>Hyd: Mount LiquidGlassBackdrop, attach pointermove
+    Hyd->>Hyd: Wait for IntersectionObserver(threshold=0.1)
+    Hyd->>Hyd: Wait for requestIdleCallback
+    Hyd->>Lazy: dynamic import LiquidGlassWebGL
+    Lazy-->>Hyd: chunk ready
+    Hyd->>Lazy: mount <Canvas>, start uBurst tween (1200ms)
+    loop every animation frame
+      Browser->>Lazy: pointermove → pointerStore → uMx/uMy
+      Browser->>Lazy: scrollY → useScroll → uScroll
+      Lazy->>Lazy: useFrame writes uniforms; renderer ticks (demand)
+    end
+  end
+  Note over Browser: User unmounts (route change) → renderer.dispose() + listeners removed
+```
+
+---
+
+## 13. Skill Resolution
+
+**`context7-strict` invoked** — `injected`. This phase REQUIRES Context7 verification of every external API. The Context7 MCP tools were not available in this execution environment; all five lookups are explicitly marked **deferred to the apply phase** with the assumption each forces and the mitigation if wrong. The orchestrator MUST run these lookups in `sdd-apply` BEFORE writing the corresponding code.
+
+| # | Library | Deferred lookup | Assumption forced | Mitigation if wrong |
+|---|---------|-----------------|-------------------|---------------------|
+| 13.1 | `@react-three/fiber` v9 + `next` 16 | Canvas `frameloop="demand"`, `useFrame` signature, React 19 root API, Next 16 `dynamic({ssr:false})` placement rules | r3f v9 supports React 19; `dynamic({ssr:false})` works inside a `"use client"` wrapper component; `frameloop="demand"` is still a valid Canvas prop | If `dynamic({ssr:false})` requires direct call from a Server Component, restructure to import `LiquidGlassWebGL` directly in `HeroSection.tsx` (RSC) and put the capability gate inside the dynamic component. If r3f v9 incompatible, pin r3f canary or fall back to `ogl` (~12 KB) + hand shader (proposal plan-B). |
+| 13.2 | `@react-three/drei` `MeshTransmissionMaterial` | Exact prop set: `transmission`, `thickness`, `ior`, `chromaticAberration`, `distortion`, `distortionScale`, `temporalDistortion`, `samples`, `resolution`, `backside`, `backsideThickness`. Subpath import `@react-three/drei/core/MeshTransmissionMaterial` exists. | All listed props are supported in current drei; subpath works | If a prop name has changed (e.g., `chromaticAberration` → `chromaticAberrationStrength`), align with the current API. If subpath fails, use top-level import + rely on `sideEffects:false` tree-shake. If the material requires WebGL2 explicitly, our gate already covers it; if it requires render-target setup, drei encapsulates it (verified in drei source historically). |
+| 13.3 | `framer-motion` 12.38.0 | `useScroll({ target, offset })` accepts `["start start", "end start"]` as valid offset tuple in v12; `useTransform` MotionValue interop with non-React consumers via `.get()` is stable | Signature unchanged from v11 | If offset format changed, update to v12's syntax. If `LazyMotion`/`m` import needed at the layer level, wrap. Already imported via `ObsidianStream`, so the bundle shape is known. |
+| 13.4 | `next-intl` 4.9.1 | `useTranslations("hero")` works in async Server Components with `params` as Promise (Next 16 `params` is async); locale resolution is automatic via middleware | Works as documented | If async RSC requires `getTranslations({ locale: (await params).locale })`, switch — semantically identical for our usage. |
+| 13.5 | `next` 16 | `next/dynamic` with `ssr:false` from a Client Component is supported; Turbopack tree-shakes drei via `sideEffects` field | True | If Turbopack misses the tree-shake, configure `experimental.optimizePackageImports = ["@react-three/drei"]` in `next.config.ts` (this is the documented escape hatch as of Next 14+). |
+
+**Honest reporting**: this design phase did not perform live Context7 calls because the tooling was not exposed in this executor's tool set. The architectural choices remain valid because (a) they're consistent with widely-documented public behavior of these libraries through 2024-2025, (b) every assumption above has a concrete fallback, and (c) the apply phase has a checklist of five mandatory lookups before any code is written. If `sdd-apply` discovers a contradiction, it pauses and routes back to design.
+
+---
+
+**Phase status**: complete. Ready for `sdd-tasks` (consumes this design + spec).

--- a/openspec/changes/hero-liquid-glass-redesign/explore.md
+++ b/openspec/changes/hero-liquid-glass-redesign/explore.md
@@ -1,0 +1,186 @@
+# Exploration: hero-liquid-glass-redesign
+
+## User Intent
+> "Quiero que te olvides de la actual primera sección de presentación y quiero que te vueles la cabeza pensando en una primera sección totalmente diferente y renovada en donde uno diga 'hay wey este cabrón sí sabe', todo basado en liquid glass y sus físicas como prioridad y bien pensado para SEO."
+
+Translation: throw away the current hero. Build a "wow, this guy knows his stuff" hero with **liquid glass + real physics** as the design priority, AND engineered for SEO.
+
+Non-negotiables:
+1. Liquid-glass aesthetic with believable physics (refraction, distortion, fluid motion, parallax/cursor reactivity).
+2. SEO-clean: SSR semantic content, single h1, JSON-LD compatible, LCP/INP healthy.
+
+## Current State
+
+### Files
+- `apps/portfolio/components/fragments/HeroFragment.tsx` (240 lines, "use client") — current hero.
+- `apps/portfolio/components/fragments/HeroFragment.test.tsx` — only asserts decorative `aria-hidden` isolation.
+- `apps/portfolio/components/ObsidianStream.tsx:155-158` — wraps hero in `<section id="hero" class="stream-section">` inside `<main id="main-content">`.
+- `apps/portfolio/app/[locale]/page.tsx:86-95` — emits `Person` JSON-LD with name, jobTitle (=headline), description (=bio), url, sameAs, knowsAbout.
+- `apps/portfolio/app/[locale]/layout.tsx` — emits `Metadata` (title, description, OG, Twitter) at locale layout.
+- `apps/portfolio/app/globals.css` — Tailwind v4 `@theme`, ember/void tokens, fluid type scale, body noise overlay, `stream-section` utility.
+- `apps/portfolio/messages/en.json` (and `es.json`) — `hero.*` namespace.
+
+### Component Tree (current)
+```
+section.stream-fragment (no h1, no header, just <section>)
+├── div (radial mouse spotlight, hidden md:block)
+├── div (grid overlay, aria-hidden)
+├── motion.div (container, animated stagger)
+│   ├── motion.div ("[SYSTEM_READY]: INITIALIZING_NEURAL_UPLINK" badge)
+│   ├── motion.div (titleLines[] → GlitchText, NOT inside any h1)
+│   └── motion.div (headline+subheadline glass card + CTA button)
+├── TelemetryPanel (aria-hidden)
+├── div COORDS readout (aria-hidden)
+└── ScrollIndicator
+```
+
+### Critical SEO finding
+**There is NO `<h1>` anywhere in `apps/portfolio`.** Confirmed via repo-wide grep. The hero displays "SYSTEM / ARCHITECT" via GlitchText spans inside divs. The page leans on `<title>` + JSON-LD only. This redesign MUST introduce a single semantic `<h1>` as the LCP candidate. This is an SEO regression that the redesign turns into an opportunity.
+
+### i18n keys consumed
+- `hero.titleLine1`, `hero.titleLine2`, `hero.headline`, `hero.subheadline`, `hero.cta`, `hero.telemetryLatency`, `hero.telemetryFramework`
+- `brand.systemReady`, `brand.uplink`, `brand.descent`
+- `profile.headline` (Sanity, falls back to `hero.headline`)
+
+### SEO/metadata currently emitted
+- Per-locale `<title>` and `<description>` via `generateMetadata` (page.tsx:28-67).
+- OpenGraph + Twitter card.
+- Canonical + hreflang alternates `/en`, `/es`.
+- JSON-LD `Person` (page.tsx:86-102).
+- `<header class="sr-only">` skip-content + nav landmarks.
+
+### Dependencies / shared UI in use
+- `framer-motion ^12.38.0` (LazyMotion+domAnimation).
+- `next-intl ^4.9.1`.
+- `@hstrejoluna/ui`: `GlitchText`, `BootSequence`, `useReducedMotion`, `GlassNav`, `HudChip`, `MicroInteraction`, `TelemetryHUD`, `CommandSurface`, etc.
+- `@hstrejoluna/compliance` — consent-driven scripts.
+- NO three.js, no @react-three/fiber, no ogl, no pixi, no canvas anywhere today.
+
+## Design Tokens Available
+
+### Color (globals.css + packages/ui/src/styles/tokens.css)
+- Base: `--color-background #131313`, `--color-void #131313`.
+- Surfaces ladder: `surface-container-lowest #0e0e0e` → `surface-bright #393939`.
+- Brand: `--color-primary #ffb4a5` (= `--color-ember`), `--color-primary-container #ff5637`, `--color-tertiary #ffb693`.
+- On-color: `--color-on-background #e2e2e2`, `--color-on-surface-variant #e9bcb3`.
+
+### Typography
+- Sans: Inter; Display: Space Grotesk; Mono: JetBrains Mono.
+- Fluid scale: `--text-fluid-hero clamp(3.5rem, 15vw, 13rem)`, `-h2`, `-h3`, `-h4`, `--text-label-sm`.
+
+### Existing glass / motion utilities
+- `backdrop-blur-xl` already used.
+- Body noise overlay (SVG turbulence, soft-light blend).
+- `.grid-with-life` animated gradient utility.
+- Glitch keyframes, scanlines, grid-pulse.
+- `prefers-reduced-motion` already wired.
+- NO SVG `<filter>` defs, NO Houdini paint, NO canvas/WebGL today.
+
+## Liquid Glass Physics — Option Comparison
+
+| Approach | Bundle (gz) | LCP risk | INP risk | A11y | SEO | Verdict |
+|----------|-------------|----------|----------|------|-----|---------|
+| **A. CSS-only**: SVG `feTurbulence`+`feDisplacementMap`+`feGaussianBlur`+`feColorMatrix` (gooey) under `backdrop-filter: blur()`, `mask-image`, conic gradients, CSS custom props for cursor (`--mx`, `--my`) | ~0 KB JS extra | None | Low | Excellent | Excellent | **Strong default**. Apple liquid-glass look reproducible at zero JS. |
+| **B. WebGL via r3f** + `MeshTransmissionMaterial` for refraction + raymarched SDF blobs | +180–250 KB gz | High if canvas is LCP | Medium | Reduced-motion fallback needed | Neutral if behind SSR text | Heavy. Reserve for hover/idle, not above-fold paint. |
+| **C. Hybrid (RECOMMENDED)**: SSR semantic markup paints first (h1, p, CTA, JSON-LD). Below text: layered SVG goo + CSS glass + cursor-reactive blobs (option A) ALWAYS visible. Optional WebGL refraction lazy-mounted via `requestIdleCallback` + IntersectionObserver, gated by `prefers-reduced-motion: no-preference` AND `hardwareConcurrency >= 4` AND `(min-width: 1024px)`. | +0 KB initial / +180 KB lazy on capable devices | None | Low | Reduced-motion gets static A; no-WebGL gets A | Excellent | **Recommended**. |
+| **D. OGL** (~12 KB gz) + custom GLSL fragment shader (refraction + Voronoi + noise) | +12–20 KB gz | Low if lazy | Low | Same as B | Same as B | Lighter alt to B. Plan-B inside hybrid. |
+| **E. Canvas 2D metaballs** (marching squares or `globalCompositeOperation: 'difference'`) | +5 KB gz | Low | Medium (CPU) | Same | Same | Skip — option A dominates. |
+
+### Why CSS goo + backdrop-filter rivals WebGL
+Apple's "Liquid Glass" (iOS 18 / visionOS) is mostly:
+- Translucent volumes with `backdrop-filter: blur()` + saturation + brightness.
+- Edge highlights via animated conic gradients.
+- Subtle refraction approximated via SVG `feDisplacementMap` driven by `feTurbulence`.
+- Specular sheen via animated radial gradient masked to glass shape.
+- Composited over a slowly-drifting backdrop (radial blobs).
+
+This stack reproduces ~90% of the perceptual effect at 0 KB JS, runs at 60–120 fps on mid-range mobile, and never blocks LCP. WebGL refraction adds the last 10%, worthwhile only on capable hardware.
+
+### Library candidates (proposal phase decides; DO NOT install yet)
+- **Already in repo**: `framer-motion` (entrance + stagger only).
+- **CSS-only stack**: zero new deps. SVG `<filter>` defs inline, CSS custom props for cursor.
+- **Optional WebGL**: `@react-three/fiber` + `@react-three/drei` (MeshTransmissionMaterial) OR `ogl` (~12 KB) + hand-written fragment shader. `lygia` shader chunks (`refract`, `fbm`, `voronoi`).
+- **Per-character text physics** (optional): Splitting via `Intl.Segmenter` + `motion.span` per grapheme.
+
+## SEO Constraints (mandatory)
+
+### MUST
+1. **Single `<h1>`** in the hero, plain text (NOT inside canvas, NOT inside SVG `<text>`). Currently absent — fixing it is part of this change.
+2. **Semantic landmark**: `<section aria-labelledby="hero-title">`. The hero must have `aria-labelledby` pointing at the h1.
+3. **First meaningful paragraph** in SSR HTML — describes role, value prop, primary keyword cluster ("Senior Software Architect", "frontend engineer", "scalable ecosystems").
+4. **CTA with descriptive anchor text** — pair with meaningful `aria-label`.
+5. **LCP candidate must be the h1 text**, not a canvas. Canvas mounts after first paint via `useEffect` + `requestIdleCallback`.
+6. **JSON-LD compatibility**: `Person` schema already in page.tsx — extend with `image`, `jobTitle`, `mainEntityOfPage` as needed.
+7. **next-intl translatable**: every visible string in the hero MUST come from `messages/{locale}.json`.
+8. **Reduced-motion fallback**: `useReducedMotion()` available from `@hstrejoluna/ui`. Static gradient + frozen blobs when `true`.
+9. **Hreflang + canonical** already set at page level.
+10. **Heading order**: hero h1 → next sections start at h2.
+
+### MUST NOT
+- No text rendered inside `<canvas>` or `<svg><text>` for SEO copy.
+- No CSS `display: none` on the h1.
+- No 100vh hero image as LCP at the cost of TBT.
+- No hydration-suspended hero — must be in initial SSR HTML.
+
+## Recommended Direction
+
+**Hybrid architecture (option C)**:
+
+1. **Server Component shell** (`HeroSection.tsx`, RSC, no `"use client"`):
+   - `<section id="hero" aria-labelledby="hero-title">`
+   - `<p>` overline (eyebrow text, mono badge, translatable)
+   - `<h1 id="hero-title">` with two visible spans (one solid, one outlined/ghosted), no `aria-hidden` on visible text
+   - `<p class="lead">` headline + subheadline (LCP candidate)
+   - `<a href="#projects">` primary CTA + descriptive `aria-label`
+   - `<a>` secondary CTA (LinkedIn/GitHub) — boosts E-E-A-T
+   - JSON-LD remains at page level.
+2. **Liquid-glass backdrop layer** (`LiquidGlassCanvas.tsx`, client, `aria-hidden`):
+   - SSR-safe CSS-only base: 3 animated radial-gradient blobs drifting via CSS keyframes, modulated by cursor via `--mx/--my` (rAF-throttled).
+   - SVG `<filter>` def with `feTurbulence` + `feDisplacementMap` applied as `filter: url(#liquid-goo)` for gooey edges.
+   - Foreground glass card uses `backdrop-filter: blur(24px) saturate(180%) brightness(1.1)`, conic-gradient highlight border, animated specular sweep on hover.
+3. **Progressive WebGL layer** (`LiquidGlassWebGL.tsx`, lazy `next/dynamic` `{ ssr: false }`):
+   - Mounted only when ALL: `useReducedMotion() === false`, `(min-width: 1024px)`, `hardwareConcurrency >= 4`, in viewport.
+   - Fragment shader: refraction (sample pre-rendered gradient texture) + chromatic aberration on edges + Voronoi cells + slow noise.
+   - Uses `ogl` (~12 KB) over r3f for tight budget. r3f acceptable if team prefers ergonomics (~150 KB extra).
+   - Hidden BEHIND the glass card (z-index discipline) so text never sits over noisy WebGL.
+4. **Cursor-reactive physics**: single `pointermove` listener at section level updates CSS vars `--mx`, `--my`, `--vx`, `--vy` on rAF. Zero React rerenders.
+5. **Entrance choreography**: `framer-motion` `LazyMotion`+`domAnimation` staggers eyebrow → h1 char-by-char → lead → CTAs. Reduced-motion → fade-in only.
+
+### Fallback (if WebGL ships nothing)
+The CSS-only base IS the production hero. WebGL is purely additive. Phase 1 (CSS) ships, Phase 2 (WebGL) follows behind a flag.
+
+## Open Questions for the User (≤ 3)
+
+1. **Bundle budget**: OK with +180 KB gz for r3f WebGL (gated to capable desktops only), or strictly cap and use `ogl` ~12 KB hand-written shader?
+2. **Copy direction**: keep "SYSTEM / ARCHITECT" + "INITIATE SEQUENCE" cyberpunk voice, or pivot to SEO-friendly h1 like "Héctor Trejo Luna — Senior Frontend Architect" with kinetic vibe in visuals only? (Recommendation: pivot — SEO needs name + keyword in h1.)
+3. **Scope of "physics"**: cursor-reactive blobs + refraction is in scope. Add scroll-driven distortion (parallax warp) and entrance-burst splash, or keep idle-elegant?
+
+## Risks
+- **Bundle weight** — only if option B/D ship; mitigated by lazy + capability gate.
+- **Hydration mismatch** — backdrop CSS vars must initialize inside `useEffect`. Strict client/server boundary documented in proposal.
+- **Mobile GPU heat / battery** — WebGL disabled on mobile. CSS layer uses `transform`/`opacity` only.
+- **`backdrop-filter` browser support** — Safari/Chrome/Firefox 103+ OK; need fallback `background: rgba(...)` for older browsers.
+- **Contrast over fluid background** — WCAG 2.2 AA 4.5:1. Glass card needs sufficiently opaque tinted backdrop layer behind h1+p. Verify with axe + manual contrast.
+- **SEO regression** — currently NO h1 exists; this redesign FIXES it. Risk reversed: SEO win.
+- **Motion sickness** — `prefers-reduced-motion` strictly honored. Parallax ≤ ±5 px when reduced.
+- **Test churn** — `HeroFragment.test.tsx` will break. New name (`HeroSection`?) needs fresh suite. Vitest + Storybook + Playwright a11y in scope.
+- **i18n coverage** — new copy in en.json AND es.json simultaneously. `messages/en.test.ts` enforces parity.
+- **Sanity profile dependency** — keep `profile?.headline` fallback so CMS edits flow.
+
+## Affected Modules
+- `apps/portfolio/components/fragments/HeroFragment.tsx` — REPLACE (or rename to `HeroSection.tsx`).
+- `apps/portfolio/components/fragments/HeroFragment.test.tsx` — REWRITE.
+- `apps/portfolio/components/ObsidianStream.tsx` — update import + `<section id="hero">` wrapper.
+- `apps/portfolio/messages/en.json`, `messages/es.json` — new `hero.*` keys; deprecate old after migration.
+- `apps/portfolio/messages/en.test.ts`, `es.test.ts` — parity assertions.
+- `apps/portfolio/app/globals.css` — `@layer utilities` for `.liquid-glass`, `.glass-card`, SVG goo filter rule.
+- `apps/portfolio/app/[locale]/page.tsx` — extend `Person` JSON-LD with `image` and `mainEntityOfPage` if proposal decides.
+- `packages/ui/src/components/LiquidGlassCanvas.tsx` (NEW) — shared backdrop primitive.
+- `packages/ui/src/components/LiquidGlassWebGL.tsx` (NEW, optional Phase 2).
+- `packages/ui/src/index.ts` — re-export.
+- `apps/portfolio/e2e/` — new Playwright spec asserting h1, `aria-labelledby`, reduced-motion, Lighthouse SEO ≥ 95.
+- `apps/portfolio/lighthouserc.cjs` — verify thresholds.
+- Storybook: stories for new components.
+
+## Skill Resolution
+context7-strict was injected. No library-specific code written here. If proposal commits to r3f/drei/ogl/lygia, the proposal phase MUST resolve library IDs and query Context7 for current API before any apply phase touches code.

--- a/openspec/changes/hero-liquid-glass-redesign/proposal.md
+++ b/openspec/changes/hero-liquid-glass-redesign/proposal.md
@@ -1,0 +1,271 @@
+# Proposal: hero-liquid-glass-redesign
+
+## 1. Intent & Why
+
+**El "wow" en una frase**: cuando alguien aterrice en `hectorTrejoLuna.com`, lo primero que vea sea un hero con vidrio líquido fotorrealista — la luz se refracta, los blobs siguen al cursor con inercia, el scroll deforma el cristal, y al cargar explota un splash líquido — todo encima de un `<h1>` semántico que un crawler indexa en milisegundos. Un visitante humano dice "qué cabrón sabe lo que hace"; Googlebot dice "Senior Frontend Architect, indexed".
+
+**Los dos no-negociables**:
+1. **Liquid glass con física real** — refracción `MeshTransmissionMaterial`, blobs cursor-reactivos, distorsión guiada por scroll, entrance burst.
+2. **SEO de nivel arquitecto** — único `<h1>` SSR con nombre + rol como ancla, lead con cluster de palabras clave, JSON-LD `Person` extendido, LCP < 2.5s.
+
+**Por qué ahora**: el hero actual (`HeroFragment.tsx:127-240`) **no tiene `<h1>` en ninguna parte** — la palabra "ARCHITECT" vive dentro de `GlitchText` spans en divs decorativos. Es una regresión SEO confirmada por grep en todo el repo (`apps/portfolio`). Además, la estética cyberpunk genérica ("[SYSTEM_READY]: INITIALIZING_NEURAL_UPLINK") no comunica nivel de arquitecto senior — comunica "plantilla descargada". Este rediseño convierte un agujero SEO en una victoria y planta una bandera técnica con física que se siente real.
+
+## 2. Scope
+
+### In scope
+- Reemplazo total de `apps/portfolio/components/fragments/HeroFragment.tsx` por un nuevo `HeroSection` (Server Component shell + dos capas cliente).
+- Nuevas primitivas compartidas en `packages/ui`:
+  - `LiquidGlassBackdrop.tsx` (capa CSS + SVG goo, siempre activa, aria-hidden).
+  - `LiquidGlassWebGL.tsx` (capa r3f, lazy, capability-gated).
+  - `useLiquidPointer.ts` (hook compartido: pointer → CSS vars + signal/ref store para uniforms r3f).
+- Las cuatro físicas:
+  1. Cursor-reactive blobs (CSS layer, siempre).
+  2. Refracción sobre contenido (r3f `MeshTransmissionMaterial`).
+  3. Scroll-driven distortion (framer-motion `useScroll` → uniform `uScroll`).
+  4. Entrance burst (uniform `uBurst` ramping 0→1→idle on mount).
+- Nuevo h1 SEO + lead + CTA + secondary link en `messages/en.json` y `messages/es.json` (paridad enforced).
+- Extensión de JSON-LD `Person` en `app/[locale]/page.tsx` con `image` y `mainEntityOfPage`.
+- Tests: vitest unit (HeroSection contract), Storybook stories (default / reduced-motion / no-WebGL / hover / scroll), Playwright a11y + h1 assertion + Lighthouse SEO ≥ 95.
+- `qa:gate` extension: bundle-size assertion para el chunk WebGL (≤ 200 KB gz).
+- Feature flag `NEXT_PUBLIC_HERO_LIQUID` para rollback en producción.
+
+### Out of scope
+- Otros fragments (`SignatureFragment`, `ProjectsFragment`, etc.) — solo hero.
+- Cambios en el schema Sanity (`profile.headline` se sigue consumiendo como fallback dentro del lead).
+- App `maestros-del-salmon` (este cambio toca `apps/portfolio` y `packages/ui` únicamente).
+- Backend / CMS / CI infra changes más allá de `qa:gate`.
+- Reescritura del sistema de tokens (se reusan `--color-ember`, `--color-void`, fluid type scale ya existentes).
+
+## 3. Approach
+
+### Architecture overview
+
+Tres capas con responsabilidades estrictamente separadas:
+
+```
+┌──────────────────────────────────────────────────────┐
+│ HeroSection.tsx  (RSC, SSR)                          │
+│  <section aria-labelledby="hero-title">              │
+│   <p className="eyebrow"> {t.eyebrow} </p>           │
+│   <h1 id="hero-title"> Héctor Trejo Luna —           │
+│        Senior Frontend Architect </h1>               │
+│   <p className="lead"> {profile?.headline ?? t.lead} │
+│   <a href="#projects" aria-label=…> {t.cta} </a>     │
+│   <a href={linkedin}> {t.secondary} </a>             │
+│   <LiquidGlassBackdrop />   ← client island          │
+│   <LiquidGlassWebGL />       ← lazy client island    │
+│  </section>                                          │
+└──────────────────────────────────────────────────────┘
+        │                                │
+        ▼                                ▼
+┌──────────────────────┐  ┌─────────────────────────────────┐
+│ LiquidGlassBackdrop  │  │ LiquidGlassWebGL  (lazy)        │
+│ "use client"         │  │ next/dynamic { ssr:false }      │
+│ aria-hidden          │  │ aria-hidden                     │
+│ CSS gradients        │  │ r3f Canvas + drei               │
+│ SVG <filter> goo     │  │ MeshTransmissionMaterial plane  │
+│ backdrop-filter      │  │ uniforms: uMouse, uScroll,      │
+│ rAF cursor → CSS vars│  │           uBurst, uTime         │
+└──────────────────────┘  └─────────────────────────────────┘
+        ▲                                ▲
+        └────── useLiquidPointer ────────┘
+                (single rAF listener,
+                 writes to ref store +
+                 CSS custom properties)
+```
+
+**Razón clave**: el RSC paint pinta el `<h1>` en el primer byte HTML — ese es el LCP candidate. Las dos capas cliente son `aria-hidden` y se montan después de hidratación, ninguna bloquea el paint inicial. La WebGL solo aterriza si el dispositivo lo aguanta.
+
+### Mount sequence (orden de eventos)
+
+1. **SSR**: Next.js renderiza `HeroSection` en HTML estático. h1 + lead + CTA están en el primer byte. JSON-LD `Person` ya está en `<head>`.
+2. **Hydration**: `LiquidGlassBackdrop` (cliente, eager) se monta. Las CSS variables `--mx`, `--my` se inicializan en `useEffect` (nunca SSR — evita hydration mismatch). Blobs empiezan a derivar.
+3. **Idle + viewport check**: `requestIdleCallback` + `IntersectionObserver(threshold:0.1)` dispara el capability gate.
+4. **Capability gate** (todas deben pasar):
+   - `useReducedMotion() === false`
+   - `window.matchMedia("(min-width: 1024px)").matches`
+   - `navigator.hardwareConcurrency >= 4`
+   - `navigator.connection?.saveData !== true`
+   - WebGL2 disponible (`canvas.getContext("webgl2")`).
+5. **WebGL mount**: si pasa, `next/dynamic(() => import("./LiquidGlassWebGL"), { ssr: false })` carga el chunk. Canvas r3f monta. Uniform `uBurst` corre de 0 → 1 → 0 en ~1.2s (entrance splash). Uniform `uTime` empieza loop.
+6. **Listeners**: `useLiquidPointer` engancha `pointermove` (passive) en la sección, escribe a `--mx`/`--my` (CSS) y a un `useRef<{ x, y }>` que el `useFrame` de r3f lee directo (cero re-renders React).
+7. **Scroll**: `useScroll({ target: heroRef, offset: ["start start", "end start"] })` produce `scrollYProgress`. `useTransform(progress, [0, 1], [0, 0.6])` alimenta `uScroll`. Reduced-motion → clamp a 0.
+8. **Teardown**: en unmount o cambio a `prefers-reduced-motion`, se cancela rAF, se libera el WebGL context (`renderer.dispose()`), se desmontan listeners.
+
+### Capa CSS (LiquidGlassBackdrop) — siempre activa
+
+- 3 blobs radiales (`radial-gradient`) animados con `transform: translate3d(var(--mx), var(--my), 0) scale(...)`.
+- `<svg><filter id="liquid-goo"><feTurbulence baseFrequency=… ><feDisplacementMap scale=… /></filter></svg>` aplicado vía `filter: url(#liquid-goo)` al contenedor de blobs.
+- `backdrop-filter: blur(24px) saturate(180%) brightness(1.05)` sobre la tarjeta del lead (legibilidad WCAG AA).
+- Conic-gradient highlight border + sweep animado para el sheen especular.
+- Honors `prefers-reduced-motion` → blobs se congelan, sin sweep.
+
+### Capa WebGL (LiquidGlassWebGL) — opcional, lazy
+
+- `@react-three/fiber` `<Canvas dpr={[1, 1.5]} frameloop="demand">` (demand frameloop para que solo renderice cuando hay cambios detectados — ahorra batería).
+- Una `<mesh>` plana ocupando el viewport, material `<MeshTransmissionMaterial>` de drei con props: `transmission={1}`, `thickness={1.5}`, `ior={1.4}`, `chromaticAberration={0.05}`, `distortion`, `distortionScale`, `temporalDistortion`.
+- Custom `onBeforeCompile` shader patch: añade un uniform `uBurst` que multiplica `distortion` durante el splash inicial; añade `uScroll` que modula `temporalDistortion`; añade `uMouse` para un displacement local centrado en el cursor.
+- `useFrame((state, delta) => { material.uniforms.uTime.value += delta; ... })` lee el ref store de `useLiquidPointer` (sin estado React).
+
+**Disclaimer Context7**: las props/API exactas de `MeshTransmissionMaterial` y el patrón `onBeforeCompile` deben verificarse contra Context7 en `sdd-design` antes de codear. La elección de `r3f + drei` se confirma a nivel arquitectura aquí; los detalles de uniforms se cierran en el design phase.
+
+### Data flow
+
+- **i18n**: `useTranslations("hero")` para todo lo visible. Nuevas keys: `eyebrow`, `h1Name`, `h1Role`, `lead`, `cta`, `ctaAriaLabel`, `secondaryLabel`, `secondaryHref` (LinkedIn URL aunque sea constante, fácil de localizar).
+- **Sanity**: `profile?.headline` sigue consumiéndose pero **dentro del lead paragraph**, no en el h1. El h1 es la verdad canónica del sitio (nombre + rol). Esto desacopla SEO del CMS.
+- **JSON-LD**: en `app/[locale]/page.tsx`, extender el schema `Person` con:
+  - `image`: URL del avatar de Sanity.
+  - `mainEntityOfPage`: `{ "@type": "WebPage", "@id": "https://hectortrejoluna.com/{locale}" }`.
+
+### Decisiones que se cierran AHORA en este proposal
+
+#### 1. Copy del h1 — **DECIDIR**
+
+Tres candidatos, recomendación al final:
+
+| # | h1 | Pros | Contras |
+|---|-----|------|---------|
+| A | `Héctor Trejo Luna — Senior Frontend Architect` | Corto, directo, exact-match para "Senior Frontend Architect" | "Frontend" puede limitar alcance vs. "Software" |
+| B | `Héctor Trejo Luna · Senior Software Architect engineering scalable ecosystems` | Cluster keywords ricos, alcance amplio | Largo, h1 de 78 chars empieza a ser excesivo |
+| C | `Héctor Trejo Luna — Senior Software Architect` | Match exacto con jobTitle del JSON-LD ya existente, conciso | Ligeramente menos específico que A |
+
+**Recomendación**: **Opción C** (`Héctor Trejo Luna — Senior Software Architect`). Razones:
+- El JSON-LD `Person` actual ya emite `jobTitle: profile.headline` (que en producción es "Senior Software Architect"). Mantener consistencia entre h1 visible y `jobTitle` estructurado refuerza la señal SEO.
+- "Software" cubre frontend + backend + arquitectura de sistemas — alcance estratégico mayor que "Frontend".
+- 47 chars: dentro del rango ideal (40-60) para SERP titles cuando el h1 también compite por title-tag bias.
+- "Frontend Architect" puede ir como cluster en el lead paragraph o como `knowsAbout` en JSON-LD (ya está).
+
+> **Decisión propuesta**: `Héctor Trejo Luna — Senior Software Architect`. El `—` (em dash) es separador semántico fuerte y reconocido por crawlers. Variantes localizadas: en = "Senior Software Architect", es = "Arquitecto Senior de Software". El nombre NO se traduce.
+
+#### 2. WebGL stack — **CONFIRMADO**
+
+`@react-three/fiber` + `@react-three/drei`. Razones (consistentes con la decisión del usuario):
+- `MeshTransmissionMaterial` out of the box en drei → cero shader artesanal para el 80% del look.
+- API ergonómica para el equipo (futuras apps en el monorepo se pueden beneficiar).
+- Compatibilidad con React 19 + Next.js 16 — **debe verificarse en Context7** (ver §9).
+- Costo: ~150 KB gz (`three` core) + ~30 KB gz (`drei` tree-shaken al usar solo `MeshTransmissionMaterial` y opcionalmente `Float`/`shaderMaterial`) ≈ 180 KB gz. Dentro del presupuesto declarado por el usuario.
+
+**Plan-B**: si Context7 revela incompatibilidad de r3f con Next.js 16 RSC sin workaround viable, el design phase puede pivotear a `ogl` (~12 KB) + shader artesanal con `lygia` chunks. Esto es escenario remoto — `@react-three/fiber` v9 ya soporta React 19.
+
+#### 3. Bundle gate — **HARD CAP 200 KB gz**
+
+- Initial JS de `apps/portfolio` no debe crecer más de **+5 KB gz** (CSS layer es esencialmente gratis; el wrapper de `next/dynamic` es ~1 KB).
+- Lazy chunk WebGL ≤ **200 KB gz** total (incluye three + drei + el componente).
+- Asserción mecánica: agregar a `qa:gate` un check con `@next/bundle-analyzer` o lectura directa de `.next/analyze` JSON.
+
+#### 4. Capability matrix — **LOCKED**
+
+WebGL solo monta cuando TODAS son verdaderas:
+
+| Check | Razón |
+|-------|-------|
+| `prefers-reduced-motion: no-preference` | Accesibilidad WCAG 2.3.3 |
+| `(min-width: 1024px)` | Móviles excluidos: GPU térmica + batería |
+| `hardwareConcurrency >= 4` | Filtra dispositivos low-end |
+| `connection.saveData !== true` | Honra Save-Data hint |
+| WebGL2 disponible | Sin fallback degradado para edge cases |
+| `IntersectionObserver` ratio ≥ 0.1 | No carga si el hero está fuera del viewport |
+
+#### 5. Feature flag — **`NEXT_PUBLIC_HERO_LIQUID`**
+
+Default `true` en development y staging, `true` en production tras una release estable. Mientras esté en `false`, el viejo `HeroFragment` sigue siendo el render. Permite rollback inmediato sin redeploy.
+
+## 4. Rollback Plan
+
+- **Fase 0 (este cambio)**: feature flag `NEXT_PUBLIC_HERO_LIQUID`. `ObsidianStream.tsx` lee el flag y elige entre `<HeroFragment />` (legacy) y `<HeroSection />` (nuevo). Ambos coexisten.
+- **Fase 1 (release)**: flag activado en production. Se monitorea Lighthouse, Web Vitals (LCP, INP, CLS), error rate, y métricas de engagement (scroll depth, CTA clicks) durante 7-14 días.
+- **Fase 2 (commit final)**: si todo está verde, se elimina el flag, se borra `HeroFragment.tsx` legacy, y `ObsidianStream.tsx` importa directo `HeroSection`. Una sola PR pequeña.
+- **Rollback de emergencia**: cambiar `NEXT_PUBLIC_HERO_LIQUID=false` en Vercel/CI → next deploy → vuelve al hero viejo. Cero código.
+- **Rollback git**: el cambio mantiene un boundary limpio (un commit revertible). Si el flag no es suficiente, `git revert <hash>` restaura el estado.
+
+## 5. Affected Modules (concrete paths)
+
+### Crear
+- `packages/ui/src/components/LiquidGlassBackdrop.tsx` — capa CSS + SVG goo + cursor blobs.
+- `packages/ui/src/components/LiquidGlassWebGL.tsx` — r3f Canvas + MeshTransmissionMaterial.
+- `packages/ui/src/hooks/useLiquidPointer.ts` — pointer → CSS vars + ref store.
+- `packages/ui/src/hooks/useLiquidCapability.ts` — capability gate (combina reduced-motion, viewport, hardware, connection, WebGL2).
+- `apps/portfolio/components/fragments/HeroSection.tsx` — nuevo Server Component shell.
+- `apps/portfolio/components/fragments/HeroSection.test.tsx` — vitest unit suite.
+- `apps/portfolio/components/fragments/HeroSection.stories.tsx` — Storybook (default, reduced-motion, no-WebGL, hover, scroll).
+- `apps/portfolio/e2e/hero.spec.ts` — Playwright a11y + h1 + Lighthouse SEO assertion.
+
+### Modificar
+- `apps/portfolio/components/ObsidianStream.tsx` — lee `process.env.NEXT_PUBLIC_HERO_LIQUID`, importa el nuevo o el viejo.
+- `apps/portfolio/messages/en.json` — añade keys `hero.eyebrow`, `hero.h1Name`, `hero.h1Role`, `hero.lead`, `hero.cta`, `hero.ctaAriaLabel`, `hero.secondaryLabel`. Mantiene las viejas hasta Fase 2.
+- `apps/portfolio/messages/es.json` — paridad total con en.
+- `apps/portfolio/messages/en.test.ts` y `es.test.ts` — assertions sobre las nuevas keys.
+- `apps/portfolio/app/[locale]/page.tsx` — extiende JSON-LD `Person` con `image` y `mainEntityOfPage`.
+- `apps/portfolio/app/globals.css` — `@layer utilities` para `.liquid-glass`, `.glass-card`, definiciones SVG goo en un `<svg>` global o en el componente.
+- `packages/ui/src/index.ts` — re-exporta los nuevos componentes y hooks.
+- `apps/portfolio/package.json` — añade `@react-three/fiber`, `@react-three/drei`, `three` (con `three` como peerDependency vía pnpm si aplica).
+- `apps/portfolio/lighthouserc.cjs` — verifica thresholds (SEO ≥ 95, Performance ≥ 90 desktop / ≥ 85 mobile).
+- `apps/portfolio/qa:gate` script (ubicación TBD en design phase) — añade bundle-size check para el chunk WebGL.
+- `.env.example` — documenta `NEXT_PUBLIC_HERO_LIQUID`.
+
+### Tocar levemente / verificar
+- `apps/portfolio/app/[locale]/layout.tsx` — verificar que el `Metadata` ya cubre OG image (probable que sí); ajustar si hace falta.
+- Tests existentes que importan `HeroFragment` directamente — actualizar imports cuando llegue Fase 2.
+
+### Eliminar (Fase 2, no en este cambio)
+- `apps/portfolio/components/fragments/HeroFragment.tsx`.
+- `apps/portfolio/components/fragments/HeroFragment.test.tsx`.
+
+## 6. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| LCP regression del Canvas WebGL | High si no se gatea | High | Lazy mount + IntersectionObserver + capability gate; LCP candidate es el h1 text en SSR |
+| Hydration mismatch en CSS vars del cursor | Medium | Medium | `--mx`/`--my` se inicializan SOLO dentro de `useEffect`; nada de SSR; defaults estáticos en CSS |
+| Bundle blow-up del WebGL chunk | Medium | High | Hard cap 200 KB gz; bundle-size assertion en `qa:gate`; tree-shake drei (importar solo `MeshTransmissionMaterial`) |
+| Mobile heat / battery drain | Medium | High | WebGL deshabilitado < 1024px; honra `connection.saveData`; CSS layer usa solo `transform`/`opacity` |
+| Contraste sobre fondo fluido | Medium | High | Tinted backdrop `rgba(19,19,19,0.6)` detrás del lead; axe en Playwright + verificación manual de contraste WCAG AA 4.5:1 |
+| Reduced-motion users excluidos del wow | Medium | Medium | Variante estática: gradiente fijo + blobs congelados + sin sweep + sin WebGL; aún se ve premium |
+| i18n parity drift entre en y es | Low | Medium | `messages/en.test.ts` y `es.test.ts` enforcen todas las keys de `hero.*` en ambos locales |
+| Sanity profile fallback se pierde | Low | Medium | `profile?.headline ?? t("lead")` se mantiene en el lead paragraph (NO en el h1) |
+| Test churn en HeroFragment.test.tsx | High | Low | Reescritura limpia como `HeroSection.test.tsx` con nuevo contract; el viejo test se borra en Fase 2 |
+| WebGL2 no soportado (browsers viejos) | Low | Low | Capability gate skipea el mount; CSS layer es la versión de producción de fallback |
+| r3f / drei incompat con Next.js 16 RSC | Low | Medium | Lazy mount con `next/dynamic({ ssr: false })` en un Client Component wrapper; verificar en Context7 antes de apply |
+| `MeshTransmissionMaterial` requiere setup de buffer/render-target específico | Medium | Medium | drei lo encapsula internamente; verificar props exactas en Context7; plan-B `ogl` documentado |
+
+## 7. Success Criteria
+
+- **Lighthouse SEO ≥ 95** (mobile + desktop). Baseline a medir antes de empezar; mejora documentada en verify phase.
+- **Lighthouse Performance ≥ 90 desktop, ≥ 85 mobile** (medido con `lighthouserc.cjs` en CI).
+- **LCP < 2.5s** en slow 4G mobile (CrUX threshold).
+- **INP < 200ms** sostenido durante interacción del cursor + scroll.
+- **CLS < 0.1** (sin shifts por mount tardío del WebGL — el placeholder ya ocupa su espacio).
+- **Bundle delta** de `apps/portfolio` initial JS ≤ **+5 KB gz**.
+- **Lazy chunk WebGL** ≤ **200 KB gz**.
+- **Único `<h1>` semántico** detectado por axe + Playwright `expect(page.locator("h1")).toHaveCount(1)`.
+- **Toda copy del hero** traducible (en + es paridad enforced).
+- **`prefers-reduced-motion: reduce`** produce variante estática, accesible, sin pérdida de identidad visual.
+- **Storybook stories** cubren: default, reduced-motion, no-WebGL fallback, hover, scroll states.
+- **Playwright a11y test**: 0 axe violations en el hero. `aria-labelledby` apuntando al h1 verificado.
+- **`@hstrejoluna/compliance`** — sin regresiones en consent gating (el WebGL no carga assets externos, así que no hay impacto consent).
+
+## 8. Open Questions
+
+Tras el checkpoint con el usuario, ya no hay preguntas abiertas significativas. Una nota residual:
+
+1. **¿Deprecar las viejas keys `hero.titleLine1` / `titleLine2` / `headline` / `subheadline` ahora o en Fase 2?** Recomendación: mantenerlas en este cambio (Fase 0+1) para que el feature flag pueda alternar sin romper, y borrarlas en la PR de Fase 2 junto con `HeroFragment.tsx`. Esta decisión la cierra el `sdd-tasks` phase.
+
+## 9. Skill Resolution
+
+**`context7-strict` invoked** — `injected`. Contexto del proposal:
+
+Este phase **NO escribe código**, solo arquitectura. Las verificaciones de Context7 se ejecutan en `sdd-design` y `sdd-apply`. Pre-anoto las queries que esos phases DEBEN correr antes de tocar implementación:
+
+| Library | resolve-library-id | query-docs target |
+|---------|---------------------|-------------------|
+| `@react-three/fiber` | `/pmndrs/react-three-fiber` (probable) | "Canvas frameloop demand", "useFrame", "React 19 compat", "Next.js App Router dynamic import patterns" |
+| `@react-three/drei` | `/pmndrs/drei` (probable) | "MeshTransmissionMaterial props transmission thickness ior chromaticAberration distortion temporalDistortion", "shaderMaterial onBeforeCompile" |
+| `framer-motion` | `/framer/motion` o `/grx7/framer-motion` | "useScroll target offset", "useTransform", "v12 API changes" |
+| `next` (Next.js 16) | `/vercel/next.js` | "dynamic import ssr false in Server Components", "App Router client component boundaries" |
+| `next-intl` | `/amannn/next-intl` | "useTranslations server component vs client", "messages namespace 4.9" |
+
+**Pre-resolutions ejecutadas en este proposal phase**: ninguna. La decisión de stack (r3f + drei) se basa en consenso técnico documentado del exploration phase y en la experiencia del orquestador. Las verificaciones de API se delegan a `sdd-design` y `sdd-apply` para no quemar tokens en este phase. Si el design phase descubre incompatibilidad, este proposal soporta el plan-B `ogl` documentado en §3.
+
+---
+
+**Phase status**: complete. Ready para `sdd-spec` y `sdd-design` (paralelizables).

--- a/openspec/changes/hero-liquid-glass-redesign/spec.md
+++ b/openspec/changes/hero-liquid-glass-redesign/spec.md
@@ -1,0 +1,341 @@
+# Spec Delta: hero-liquid-glass-redesign
+
+> Behavior contract for the redesigned hero. Uses RFC 2119 keywords (MUST, SHALL, SHOULD, MAY, MUST NOT). Implementation details live in `design.md`; this document describes WHAT the system MUST do.
+
+## Capabilities affected
+
+- **ADDED**: `liquid-glass-hero` (new spec)
+- **MODIFIED**: `portfolio-testing-foundation` (extends hero-related assertions)
+- **REFERENCED** (no change): `vertical-navigation-hud` (sibling fragment, listed for context only)
+
+---
+
+## ADDED — Capability: `liquid-glass-hero`
+
+### Requirement: Semantic SSR shell
+
+The hero section SHALL render a Server Component that emits in initial SSR HTML:
+
+- Exactly one `<h1>` element with id `hero-title`.
+- A `<section>` element with `aria-labelledby="hero-title"` enclosing the `<h1>`.
+- A `<p>` lead paragraph carrying the role/value-prop sentence.
+- Two `<a>` CTAs: a primary anchor pointing to `#projects` and a secondary anchor pointing to an external profile URL.
+- An eyebrow `<p>` containing the translatable mono badge.
+
+The `<h1>` text MUST contain the canonical name **and** a role keyword. The locked copy is:
+
+- en: `Héctor Trejo Luna — Senior Software Architect`
+- es: `Héctor Trejo Luna — Arquitecto Senior de Software`
+
+The h1 MUST NOT depend on Sanity content; its text is sourced exclusively from `messages/{locale}.json` under `hero.*`.
+
+#### Scenario: hero is rendered server-side
+
+- **Given** a request to `/en` or `/es`
+- **When** the page is server-rendered
+- **Then** the response HTML SHALL contain exactly one `<h1>` element inside the hero section
+- **And** that `<h1>` SHALL be the LCP candidate (text node, no `aria-hidden`, no `display:none`, no `visibility:hidden`, no `opacity:0` at first paint)
+- **And** the enclosing `<section>` SHALL reference the h1 via `aria-labelledby="hero-title"`
+
+#### Scenario: hero copy is translatable
+
+- **Given** the i18n locale is `"en"`
+- **When** the hero renders
+- **Then** every visible string in the hero SHALL come from `messages/en.json` under the `hero.*` namespace
+- **And** the same SHALL hold for locale `"es"` via `messages/es.json`
+- **And** the `messages/en.test.ts` and `messages/es.test.ts` parity checks SHALL include all `hero.*` keys
+
+#### Scenario: Sanity profile fallback (non-h1 paths only)
+
+- **Given** Sanity returns a `profile` document with `headline` set
+- **When** the lead paragraph renders
+- **Then** the lead SHALL prefer `profile.headline` and fall back to `messages.hero.lead` when `headline` is null or undefined
+- **And** the `<h1>` text SHALL never depend on Sanity (always static name + role from messages)
+
+---
+
+### Requirement: Liquid glass CSS layer (always-on)
+
+A client component `LiquidGlassBackdrop` SHALL render `aria-hidden="true"` visual layers behind the semantic shell, providing:
+
+- Three animated radial-gradient blobs drifting via CSS keyframes.
+- An SVG `<filter>` exposing `feTurbulence` + `feDisplacementMap`, applied to blob layers as `filter: url(#liquid-goo)`.
+- A glass card with `backdrop-filter: blur() saturate() brightness()` containing the h1 + lead.
+
+This layer SHALL run on ALL viewports and ALL capability profiles, including reduced-motion (in which case animations are frozen but the visual treatment remains).
+
+#### Scenario: cursor reactivity updates CSS variables only
+
+- **Given** the user moves the pointer over the hero
+- **When** the section receives a `pointermove` event
+- **Then** exactly one rAF-throttled handler SHALL update CSS custom properties `--mx`, `--my`, `--vx`, `--vy` on the section element
+- **And** no React component SHALL re-render as a consequence (verified by render-count assertion in tests)
+- **And** blobs SHALL visually follow via CSS `transform: translate(...)` reading those variables
+
+#### Scenario: reduced-motion freezes the CSS layer
+
+- **Given** `prefers-reduced-motion: reduce` is honored by the browser
+- **When** the hero mounts
+- **Then** blob keyframe animations SHALL be paused or removed
+- **And** the radial-gradient blobs SHALL be at fixed positions (no parallax, no cursor follow)
+- **And** no `pointermove` listener SHALL be attached
+- **And** the SVG goo filter SHALL still apply (purely visual, not animated)
+
+---
+
+### Requirement: WebGL refraction layer (capability-gated, lazy)
+
+A client component `LiquidGlassWebGL` SHALL be loaded lazily and mounted only when ALL of the following are true:
+
+1. `useReducedMotion()` returns false (i.e. `prefers-reduced-motion: no-preference`)
+2. `window.matchMedia('(min-width: 1024px)').matches`
+3. `navigator.hardwareConcurrency >= 4`
+4. WebGL2 context creation succeeds on a probe canvas
+5. `(navigator.connection?.saveData ?? false) === false`
+6. The hero section enters the viewport (IntersectionObserver fires with ratio ≥ 0.1)
+
+When mounted, this component SHALL render a fullscreen plane applying a transmission/refraction material to produce the liquid-glass effect.
+
+The component SHALL NOT execute during SSR.
+
+#### Scenario: WebGL skipped on small viewports
+
+- **Given** a viewport width of 768px
+- **When** the hero hydrates
+- **Then** `LiquidGlassWebGL` SHALL NOT be loaded
+- **And** the network log SHALL NOT include the WebGL chunk
+- **And** the CSS layer SHALL be the only animated visual
+
+#### Scenario: WebGL skipped under reduced-motion
+
+- **Given** the user has `prefers-reduced-motion: reduce` set
+- **When** the hero hydrates on a 1440px viewport with `hardwareConcurrency >= 8`
+- **Then** `LiquidGlassWebGL` SHALL NOT mount
+- **And** the entrance burst animation SHALL NOT play
+
+#### Scenario: WebGL skipped on save-data connections
+
+- **Given** `navigator.connection.saveData === true`
+- **When** the hero hydrates on an otherwise capable device
+- **Then** `LiquidGlassWebGL` SHALL NOT mount
+- **And** the WebGL chunk SHALL NOT be requested
+
+#### Scenario: WebGL skipped without WebGL2
+
+- **Given** WebGL2 context creation fails on the probe canvas
+- **When** the capability gate evaluates
+- **Then** `LiquidGlassWebGL` SHALL NOT mount
+
+#### Scenario: WebGL teardown on unmount
+
+- **Given** the WebGL layer is mounted
+- **When** the user navigates away from the hero (component unmounts)
+- **Then** the WebGL renderer SHALL dispose its GPU resources (textures, geometries, materials, framebuffers)
+- **And** all rAF subscriptions tied to the canvas SHALL be cancelled
+- **And** all `resize`, `pointermove`, `scroll` listeners owned by the layer SHALL be removed
+- **And** no measurable memory leak SHALL occur across 100 mount/unmount cycles in a Playwright stress test (heap delta within ±5% of baseline)
+
+---
+
+### Requirement: Entrance burst splash
+
+On the first mount of `LiquidGlassWebGL` for a given page load, a one-shot "burst" animation SHALL play.
+
+#### Scenario: burst plays once on initial mount
+
+- **Given** the WebGL layer mounts for the first time on this page load
+- **When** the canvas is ready (renderer initialized, material compiled)
+- **Then** a burst signal SHALL ramp from `0` → `1` → idle over a duration of ≤ 1200ms
+- **And** the burst SHALL play exactly once per page load (guarded by an in-memory or `sessionStorage` flag)
+- **And** subsequent unmount/remount cycles within the same page load SHALL NOT replay the burst
+
+#### Scenario: burst suppressed under reduced-motion
+
+- **Given** `prefers-reduced-motion: reduce` is set
+- **When** the hero loads
+- **Then** the burst animation SHALL NOT play (because `LiquidGlassWebGL` does not mount)
+
+---
+
+### Requirement: Scroll-driven distortion
+
+A scroll-linked signal SHALL bend the WebGL refraction while the hero is visible.
+
+#### Scenario: scroll progress maps to distortion
+
+- **Given** the WebGL layer is mounted and the hero is on screen
+- **When** the user scrolls (scroll progress 0..1 across hero height)
+- **Then** a uniform `uScroll` SHALL track scroll progress in the range [0, 1]
+- **And** the refraction material's distortion (or temporal distortion) SHALL be modulated by `uScroll`
+- **And** when `prefers-reduced-motion: reduce` is active, `uScroll` SHALL be clamped to `0` (no distortion change on scroll)
+
+#### Scenario: scroll signal stops outside hero viewport
+
+- **Given** the user has scrolled past the hero so it is no longer in viewport
+- **When** further scrolling occurs
+- **Then** `uScroll` SHALL NOT continue to update (frame loop SHALL pause or skip)
+- **And** the canvas SHALL NOT consume frame budget while off-screen
+
+---
+
+### Requirement: Performance budgets
+
+- Initial JavaScript for `apps/portfolio` SHALL increase by NO MORE than **5 KB gzipped** versus the baseline measured at proposal time.
+- The lazy WebGL chunk SHALL be ≤ **200 KB gzipped**.
+- Largest Contentful Paint (LCP) on a slow-4G mobile profile SHALL be ≤ **2.5 s**.
+- Interaction to Next Paint (INP) on hero interactions (pointer move, CTA click) SHALL be ≤ **200 ms**.
+- Cumulative Layout Shift (CLS) on initial hero render SHALL be ≤ **0.1**.
+
+#### Scenario: bundle-size assertion fails on regression
+
+- **Given** a developer adds a heavy dependency that pushes the WebGL chunk above 200 KB gz
+- **When** CI runs `qa:gate`
+- **Then** the bundle-size step SHALL fail with a non-zero exit code
+- **And** the PR SHALL be blocked from merging
+
+#### Scenario: initial JS budget is enforced
+
+- **Given** the PR introduces an unrelated heavy import that ships in initial JS
+- **When** `qa:gate` measures the initial bundle of `apps/portfolio`
+- **Then** if the delta exceeds +5 KB gz versus baseline, the step SHALL fail
+
+#### Scenario: Lighthouse LCP threshold
+
+- **Given** `qa:lighthouse` runs against the production build
+- **When** the mobile profile is scored
+- **Then** LCP SHALL be ≤ 2.5 s
+- **And** the LCP element SHALL be a text node inside the hero `<h1>`, not a canvas
+
+---
+
+### Requirement: Accessibility
+
+- The hero SHALL produce zero axe violations of any rule, any impact level.
+- All decorative liquid-glass layers (CSS blobs, SVG filter, WebGL canvas) SHALL be marked `aria-hidden="true"`.
+- The h1, lead, eyebrow, and CTAs SHALL maintain a contrast ratio ≥ **4.5:1** against their immediate background, including over the glass card surface.
+- Focus states on CTAs SHALL be visible without relying on color alone (visible outline or ring).
+- The hero SHALL be navigable via keyboard alone (Tab order: skip-link target → eyebrow link if any → CTAs in DOM order).
+
+#### Scenario: a11y test passes
+
+- **Given** the hero is rendered (in any locale, any capability profile)
+- **When** `axe.run()` is invoked in a Playwright spec
+- **Then** zero violations SHALL be reported
+
+#### Scenario: contrast over fluid background
+
+- **Given** any cursor position and any blob configuration
+- **When** the glass card is overlaid on top of the blobs
+- **Then** the background luminance behind the h1 + lead SHALL be muted enough (via the tinted/blurred backdrop) to maintain ≥ 4.5:1 contrast
+- **And** this SHALL be verified against representative states: idle, cursor at left edge, cursor at right edge, scroll at 50% of hero height
+
+#### Scenario: keyboard focus visibility
+
+- **Given** the hero is rendered on a keyboard-only profile
+- **When** the user tabs through the CTAs
+- **Then** each focused CTA SHALL display a visible focus indicator that does not rely solely on color
+- **And** the indicator SHALL be perceivable over the glass card surface
+
+---
+
+### Requirement: Rollback flag
+
+The new hero SHALL be guarded by an environment flag named `NEXT_PUBLIC_HERO_LIQUID`. Toggling this flag SHALL allow zero-code rollback to the legacy hero.
+
+#### Scenario: flag enabled renders new hero
+
+- **Given** `NEXT_PUBLIC_HERO_LIQUID` is `"true"` at build time
+- **When** the page renders
+- **Then** the new `HeroSection` component tree SHALL render
+- **And** the legacy `HeroFragment` SHALL NOT appear in the rendered tree
+
+#### Scenario: flag disabled keeps legacy hero
+
+- **Given** `NEXT_PUBLIC_HERO_LIQUID` is unset, empty, or `"false"`
+- **When** the page renders
+- **Then** the legacy `HeroFragment` SHALL render
+- **And** no liquid-glass code (CSS layer, WebGL layer, hooks, feature messages) SHALL execute on the client
+
+#### Scenario: flag value is build-time
+
+- **Given** the flag is read via `process.env.NEXT_PUBLIC_HERO_LIQUID`
+- **When** the bundle is produced
+- **Then** the unselected branch SHALL be tree-shaken out of the production bundle (verified by chunk inspection in CI)
+
+---
+
+### Requirement: SEO surface
+
+- The hero SHALL contribute exactly one `<h1>` to the document.
+- The page SHALL emit JSON-LD `Person` structured data including `name`, `jobTitle`, `image`, and `mainEntityOfPage`.
+- The Lighthouse SEO category SHALL score ≥ **95** in `qa:lighthouse`.
+
+#### Scenario: single h1 per page
+
+- **Given** the hero is rendered alongside the rest of the home page
+- **When** the DOM is inspected
+- **Then** exactly one `<h1>` element SHALL exist on the page
+- **And** that `<h1>` SHALL be inside the hero section
+
+#### Scenario: JSON-LD Person valid
+
+- **Given** the page is rendered server-side
+- **When** Google's structured-data validator (or equivalent JSON-LD lint) inspects the page
+- **Then** the `Person` block SHALL parse without errors
+- **And** SHALL contain `name`, `jobTitle`, `image`, and `mainEntityOfPage`
+
+---
+
+## MODIFIED — Capability: `portfolio-testing-foundation`
+
+### Extended scenarios
+
+#### Scenario: hero contains semantic h1 (was: NOT TESTED)
+
+- **Given** any locale (`en`, `es`)
+- **When** the hero is rendered in jsdom + Vitest
+- **Then** `screen.getByRole('heading', { level: 1 })` SHALL find exactly one element
+- **And** that element SHALL contain the canonical name + role text from `messages.hero.h1Name` + `messages.hero.h1Role`
+
+#### Scenario: Lighthouse SEO threshold raised to 95
+
+- **Given** `qa:lighthouse` runs against the production build
+- **When** the categories are scored
+- **Then** the SEO category SHALL score ≥ 95 (previous baseline: TBD / unmeasured)
+
+#### Scenario: Playwright e2e covers reduced-motion path
+
+- **Given** a Playwright project configured with `reducedMotion: 'reduce'`
+- **When** the hero is loaded
+- **Then** no `<canvas>` element SHALL be present inside the hero section
+- **And** the hero SHALL still render the h1, lead, and CTAs
+- **And** axe SHALL report zero violations
+
+#### Scenario: Playwright e2e covers desktop capable path
+
+- **Given** a Playwright project configured with viewport ≥ 1440×900 and reduced-motion `'no-preference'`
+- **When** the hero is loaded
+- **Then** a `<canvas>` element SHALL eventually appear inside the hero section (after IntersectionObserver fires)
+- **And** the burst animation SHALL be observable via uniform-state assertion or visual snapshot
+- **And** the h1 SHALL remain the LCP candidate (verified by Performance API)
+
+#### Scenario: i18n parity tests cover hero keys
+
+- **Given** the hero introduces new `hero.*` keys (eyebrow, h1Name, h1Role, lead, cta, ctaAriaLabel, secondaryLabel, secondaryHref)
+- **When** `messages/en.test.ts` and `messages/es.test.ts` run
+- **Then** every new key SHALL be present in BOTH locales
+- **And** any missing key SHALL fail the parity test
+
+---
+
+## REFERENCED — Capability: `vertical-navigation-hud`
+
+No changes. Listed for context only — the HUD is a sibling fragment of the hero and is unaffected by this delta.
+
+---
+
+## Out of scope
+
+- Phase 2 deletion of `HeroFragment.tsx` and removal of the `NEXT_PUBLIC_HERO_LIQUID` flag (separate change).
+- Sanity schema additions beyond consuming the existing `profile.headline`.
+- Replacing the WebGL stack (`@react-three/fiber` + `@react-three/drei`) with a lighter alternative — locked at proposal time, only revisited if design surfaces a blocker.

--- a/openspec/changes/hero-liquid-glass-redesign/tasks.md
+++ b/openspec/changes/hero-liquid-glass-redesign/tasks.md
@@ -1,0 +1,129 @@
+# Tasks: hero-liquid-glass-redesign
+
+## Strict TDD Mode
+ENABLED. Test runner: `npm test` (vitest from root → apps/portfolio). E2E: `npm run qa:e2e --workspace=apps/portfolio`. Each implementation task is preceded by a failing-test task (RED) and followed by a refactor task where applicable. Every requirement in `spec.md` is traced to at least one task. Run `npm test` after each GREEN; commit at refactor green.
+
+## Phase 1 — Infrastructure & Scaffolding (sequential)
+
+- [ ] 1.1 Add `NEXT_PUBLIC_HERO_LIQUID` to `apps/portfolio/.env.example` (default `"false"`) and document the rollout flag in `apps/portfolio/README.md`. *(satisfies: Rollback flag)*
+- [ ] 1.2 Create `scripts/check-bundle-size.mjs` reading the Turbopack build manifest, gzipping in-memory, asserting initial JS delta ≤ +5 KB gz vs baseline AND any chunk matching `chunks/hero-webgl-*.js` ≤ 200 KB gz. Persist baseline to `scripts/.bundle-baseline.json` (committed). *(satisfies: Performance budgets — bundle-size assertion fails on regression, initial JS budget is enforced)*
+- [ ] 1.3 Wire `node scripts/check-bundle-size.mjs` into the existing `qa:gate` script in root `package.json`. Verify non-zero exit on threshold breach via a manual stub run.
+- [ ] 1.4 Add a Playwright project named `chromium-reduced-motion` in `apps/portfolio/playwright.config.ts` (use: `{ ...devices['Desktop Chrome'], reducedMotion: 'reduce' }`). Keep existing projects intact. *(satisfies: portfolio-testing-foundation — reduced-motion path)*
+- [ ] 1.5 Update `apps/portfolio/lighthouserc.cjs` assertions: `categories:seo ≥ 0.95`, `categories:performance ≥ 0.90` (desktop preset) / `≥ 0.85` (mobile preset), `largest-contentful-paint ≤ 2500ms`, `categories:accessibility ≥ 0.95`. *(satisfies: SEO surface, Performance budgets, portfolio-testing-foundation — Lighthouse SEO threshold raised to 95)*
+
+## Phase 2 — Library Verification (Context7 — gate to Phase 3)
+
+> Each Context7 task is a precondition to its corresponding implementation task in Phase 3/4. If any lookup contradicts the design, pause apply and route back to sdd-design.
+
+- [ ] 2.1 Context7 resolve `@react-three/fiber` v9. Capture: `<Canvas frameloop="demand" dpr={[1,1.5]}>` signature, `useFrame` API in r3f v9, React 19 root compatibility notes.
+- [ ] 2.2 Context7 resolve `@react-three/drei`. Capture: `MeshTransmissionMaterial` complete prop list (`transmission`, `thickness`, `ior`, `chromaticAberration`, `distortion`, `distortionScale`, `temporalDistortion`, `samples`, `resolution`, `backside`) AND the subpath import path (`@react-three/drei/core/MeshTransmissionMaterial`) for tree-shaking.
+- [ ] 2.3 Context7 resolve `framer-motion` 12.38.0. Capture: `useScroll({ target, offset: ["start start","end start"] })` exact signature in v12, `LazyMotion + domAnimation` boundaries under Next 16 RSC.
+- [ ] 2.4 Context7 resolve `next-intl` 4.9.1. Capture: `useTranslations` in async RSC vs `getTranslations({ locale })`, which to use for the new `HeroSection` server component.
+- [ ] 2.5 Context7 resolve Next.js 16. Capture: `next/dynamic({ ssr: false })` placement rules under RSC + Turbopack tree-shake behavior for `@react-three/drei`. Note `experimental.optimizePackageImports` escape hatch.
+- [ ] 2.6 Save findings to engram as `sdd/hero-liquid-glass-redesign/context7` (so apply phase has them cached and verify can compare against actual usage).
+
+## Phase 3 — Shared Primitives in `packages/ui` (TDD, mostly sequential within a primitive, parallel across primitives)
+
+> Tasks 3.1–3.4 (motion preferences + pointer store) can run in parallel with 3.5–3.7 (CSS backdrop). 3.8 onward depends on 3.1–3.4.
+
+- [ ] 3.1 RED: Failing test `packages/ui/src/hooks/useHeroMotionPreferences.test.ts` covering 8-cell truth table → returns `{ profile: "static", ready }` under reduced-motion; `"css-only"` when any of `<1024px`, `hardwareConcurrency<4`, `connection.saveData`, no WebGL2; `"css+webgl"` otherwise. Mock `matchMedia`, `navigator`, WebGL2 probe. Returns `ready=false` during SSR. *(satisfies: WebGL refraction layer — capability gates 1–5)*
+- [ ] 3.2 GREEN: Implement `packages/ui/src/hooks/useHeroMotionPreferences.ts` returning `{ profile, ready }` discriminated union; commits real profile in `useEffect`.
+- [ ] 3.3 RED: Failing test `packages/ui/src/runtime/heroPointerStore.test.ts`: subscribe → updates on rAF; assert no React re-renders (use a render-counter component); teardown removes listener. *(satisfies: Liquid glass CSS layer — cursor reactivity updates CSS variables only)*
+- [ ] 3.4 GREEN: Implement `packages/ui/src/runtime/heroPointerStore.ts` (vanilla module, ref-style `get/set/subscribe`, rAF-throttled writer attached via `attachHeroPointerListener(sectionEl)`).
+- [ ] 3.5 RED: Failing test `packages/ui/src/components/LiquidGlassBackdrop.test.tsx`: renders `aria-hidden="true"`, mounts SVG `<filter id="liquid-goo">`, three blob divs, glass-card wrapper; under reduced-motion no `pointermove` listener attached AND blob `animation-play-state` is `paused`. *(satisfies: Liquid glass CSS layer — always-on, reduced-motion freezes)*
+- [ ] 3.6 GREEN: Implement `packages/ui/src/components/LiquidGlassBackdrop.tsx` ("use client"): SVG goo defs, three CSS blob divs reading `--mx/--my/--vx/--vy`, glass card with `backdrop-filter`. Calls `attachHeroPointerListener` only when not reduced-motion.
+- [ ] 3.7 REFACTOR: Extract repeated CSS-var math into `packages/ui/src/runtime/cssVarHelpers.ts`; ensure 3.5 still passes. Run `npm test` from root.
+- [ ] 3.8 RED: Failing test `packages/ui/src/components/LiquidGlassWebGL.test.tsx` (mount conditions): renders `<Canvas>` only when `profile === "css+webgl"` AND `intersectionRatio ≥ 0.1`; otherwise renders `null`. Mock `IntersectionObserver` + `requestIdleCallback`. *(satisfies: WebGL refraction layer — gates 1–6)*
+- [ ] 3.9 GREEN: Implement `packages/ui/src/components/LiquidGlassWebGL.tsx` skeleton: r3f `<Canvas dpr={[1,1.5]} frameloop="demand">` + `<Plane>` + `<MeshTransmissionMaterial>` (subpath import per 2.2). Uniforms placeholders: `uTime, uMx, uMy, uScroll, uBurst`. Returns `null` until gates open.
+- [ ] 3.10 RED: Failing test for entrance burst: `uBurst` ramps `0 → 1 → idle` exactly once over ≤1200ms per page load (use sessionStorage flag). Verify second mount in same page load does NOT replay. *(satisfies: Entrance burst splash)*
+- [ ] 3.11 GREEN: Implement burst tween inside `useFrame` using a `burstStore` singleton; gate by `sessionStorage.getItem("hero-burst-played")`.
+- [ ] 3.12 RED: Failing test for scroll-driven distortion: `uScroll` updates with mocked `scrollYProgress`; clamped to `0` under reduced-motion; pauses updates when hero leaves viewport. *(satisfies: Scroll-driven distortion)*
+- [ ] 3.13 GREEN: Wire `useScroll({ target: heroRef, offset: ["start start","end start"] })` + `useTransform(progress,[0,1],[0,0.6])`; read inside `useFrame` from a scroll store; pause loop when `IntersectionObserver` reports `intersectionRatio === 0`.
+- [ ] 3.14 RED: Failing test for WebGL teardown: on unmount, renderer disposes resources, rAF cancelled, listeners removed. *(satisfies: WebGL teardown on unmount)*
+- [ ] 3.15 GREEN: Implement teardown in `useEffect` cleanup of `LiquidGlassWebGL` (dispose materials/geometries/textures, cancel rAF, remove pointer/scroll listeners owned by the layer).
+- [ ] 3.16 REFACTOR: Convert drei import to subpath form (`@react-three/drei/core/MeshTransmissionMaterial`) per 2.2. Verify with bundle-size script (1.2). Run `npm test`.
+- [ ] 3.17 Add Storybook stories for `LiquidGlassBackdrop` and `LiquidGlassWebGL` under `packages/ui/src/components/*.stories.tsx`: `Default`, `ReducedMotion`, `NoWebGL`, `Hover`, `ScrollMidway`, `FlagOff`.
+- [ ] 3.18 Re-export new primitives + hooks + store from `packages/ui/src/index.ts`.
+
+## Phase 4 — `apps/portfolio` HeroSection (TDD, sequential)
+
+- [ ] 4.1 RED: Failing Vitest test `apps/portfolio/components/sections/HeroSection.test.tsx` (jsdom): renders exactly one `<h1>` with id `hero-title` and text matching the locked en copy; lead paragraph; eyebrow `<p>`; primary CTA (`href="#projects"`); secondary CTA. Each per locale (en, es). *(satisfies: Semantic SSR shell — hero is rendered server-side; portfolio-testing-foundation — hero contains semantic h1)*
+- [ ] 4.2 GREEN: Implement `apps/portfolio/components/sections/HeroSection.tsx` as RSC. Use the next-intl pattern chosen in 2.4 (likely `getTranslations({ locale })` for async RSC). Section uses `aria-labelledby="hero-title"`. Renders ONE client island: `<HeroVisualLayer/>`.
+- [ ] 4.3 RED: Failing test for Sanity profile fallback: lead uses `profile?.headline` when defined; falls back to `t("lead")` when null/undefined; h1 NEVER reads from profile. *(satisfies: Sanity profile fallback)*
+- [ ] 4.4 GREEN: Wire `profile` prop through `HeroSection`; lead reads `profile?.headline ?? t("lead")`.
+- [ ] 4.5 RED: Failing test `apps/portfolio/components/sections/HeroVisualLayer.test.tsx`: returns `null` while `ready=false`; mounts `LiquidGlassBackdrop` always when `ready` AND profile in `{"css-only","css+webgl"}`; mounts lazy `LiquidGlassWebGL` ONLY when profile === `"css+webgl"`; renders nothing animated under `"static"`. *(satisfies: WebGL skipped on small viewports / reduced-motion / save-data / no WebGL2)*
+- [ ] 4.6 GREEN: Implement `apps/portfolio/components/sections/HeroVisualLayer.tsx` ("use client") composing `LiquidGlassBackdrop` + `next/dynamic(() => import("@hstrejoluna/ui").then(m => m.LiquidGlassWebGL), { ssr: false })`. Owns section ref, capability gate via `useHeroMotionPreferences`, scroll wiring.
+- [ ] 4.7 Update `apps/portfolio/components/streams/ObsidianStream.tsx` to import `HeroSection` instead of `HeroFragment` when `process.env.NEXT_PUBLIC_HERO_LIQUID === "true"`. Keep legacy import otherwise. Add a Vitest test asserting both branches render their respective tree. *(satisfies: Rollback flag — flag enabled / disabled / build-time tree-shake)*
+- [ ] 4.8 Add new i18n keys to `apps/portfolio/messages/en.json` under `hero.*`: `eyebrow`, `h1Name`, `h1Role`, `lead`, `ctaPrimary`, `ctaPrimaryAriaLabel`, `ctaSecondary`, `ctaSecondaryAriaLabel`, `secondaryHref`. Mirror in `apps/portfolio/messages/es.json`. Use locked copy (en `Héctor Trejo Luna — Senior Software Architect`, es `Héctor Trejo Luna — Arquitecto Senior de Software`; eyebrow en `Building digital experiences`, es `Construyendo experiencias digitales`). *(satisfies: hero copy is translatable)*
+- [ ] 4.9 Update `apps/portfolio/messages/en.test.ts` and `apps/portfolio/messages/es.test.ts` parity assertions to require all new `hero.*` keys. *(satisfies: portfolio-testing-foundation — i18n parity tests cover hero keys)*
+- [ ] 4.10 RED: Failing test for JSON-LD `Person` block in `app/[locale]/page.tsx` test (`apps/portfolio/app/[locale]/page.test.tsx`): emits valid JSON-LD with `name`, `jobTitle`, `image` (Sanity URL via `urlForImage(profile.avatar).width(1200).height(630).url()` with `/og-default.png` fallback), `mainEntityOfPage`. *(satisfies: SEO surface — JSON-LD Person valid)*
+- [ ] 4.11 GREEN: Update `apps/portfolio/app/[locale]/page.tsx` to add `image` and `mainEntityOfPage` to the JSON-LD `Person` block.
+
+## Phase 5 — Styles & SEO
+
+- [ ] 5.1 Add `@layer utilities` rules in `apps/portfolio/app/globals.css` for `.liquid-glass`, `.glass-card`, blob keyframes, default `--mx:50%; --my:50%`. Add tinted backdrop tokens behind h1 + lead for contrast. *(satisfies: Accessibility — contrast over fluid background)*
+- [ ] 5.2 Add Vitest snapshot or unit test for the resolved tinted backdrop CSS-var values; document chosen tint (e.g. `rgba(0,0,0,0.45)` over blobs) in `apps/portfolio/app/globals.css` comment.
+- [ ] 5.3 Verify h1 is the LCP candidate using `PerformanceObserver` in a Playwright spec (lives in Phase 6). Note: this is the wiring task; the actual assertion task is 6.11.
+
+## Phase 6 — End-to-End Tests (TDD, sequential within a viewport, parallel across viewports)
+
+> Each spec lives under `apps/portfolio/e2e/hero-liquid-glass.spec.ts` (or split per concern). Use the `chromium-desktop`, `chromium-mobile`, `chromium-reduced-motion` projects.
+
+- [ ] 6.1 RED: Failing Playwright spec — `chromium-desktop` (1440×900): `<canvas>` mounts inside hero section within 5 s of viewport intersection. *(satisfies: portfolio-testing-foundation — desktop capable path)*
+- [ ] 6.2 GREEN: Verify capability gate causes Canvas to mount on the desktop project; adjust gate timing if necessary.
+- [ ] 6.3 RED: Failing Playwright spec — `chromium-mobile` (375×812): NO `<canvas>` in hero section AND no WebGL chunk requested in network log. *(satisfies: WebGL skipped on small viewports)*
+- [ ] 6.4 GREEN: Verify mobile path; ensure `useHeroMotionPreferences` returns `"css-only"`.
+- [ ] 6.5 RED: Failing Playwright spec — `chromium-reduced-motion` project: no canvas, no `pointermove` listener (assert via `page.evaluate` or render-count proxy), blobs static. *(satisfies: reduced-motion freezes the CSS layer; WebGL skipped under reduced-motion)*
+- [ ] 6.6 GREEN: Verify reduced-motion path.
+- [ ] 6.7 RED: Failing axe a11y test on hero section (all three projects). *(satisfies: Accessibility — a11y test passes; portfolio-testing-foundation)*
+- [ ] 6.8 GREEN: Resolve any axe violations until count is zero across all three projects.
+- [ ] 6.9 RED: Failing pixel-contrast spec at h1 region across cursor positions (idle, left edge, right edge, scroll 50%). *(satisfies: Accessibility — contrast over fluid background)*
+- [ ] 6.10 GREEN: Tune backdrop tint in `globals.css` until contrast ≥ 4.5:1 in all measured states.
+- [ ] 6.11 RED: Failing Playwright spec asserting LCP element id is `hero-title` via `PerformanceObserver` script. *(satisfies: Lighthouse LCP threshold; SEO surface — single h1 per page)*
+- [ ] 6.12 GREEN: Verify h1 wins LCP; if not, audit deferred CSS / image preloads.
+- [ ] 6.13 RED: Failing memory-leak stress test: 100 mount/unmount cycles, heap delta within ±5% baseline. Document threshold + sampling method. *(satisfies: WebGL teardown on unmount)*
+- [ ] 6.14 GREEN: Implement complete WebGL teardown to satisfy stress test (refines 3.15 with any newly discovered leaks).
+- [ ] 6.15 RED: Failing keyboard-focus spec: tab through CTAs; assert each focused CTA has a visible non-color-only indicator over the glass card. *(satisfies: Accessibility — keyboard focus visibility)*
+- [ ] 6.16 GREEN: Add focus styles in `globals.css` (outline + offset shadow) until 6.15 passes.
+
+## Phase 7 — Lighthouse + Bundle Validation
+
+- [ ] 7.1 Run `npm run qa:lighthouse --workspace=apps/portfolio`. Verify SEO ≥ 95, Performance ≥ 90 desktop / ≥ 85 mobile, LCP ≤ 2.5 s, A11y ≥ 95. *(satisfies: SEO surface; Performance budgets — Lighthouse LCP threshold)*
+- [ ] 7.2 Run `node scripts/check-bundle-size.mjs`. Verify lazy WebGL chunk ≤ 200 KB gz AND initial JS delta ≤ +5 KB gz vs `scripts/.bundle-baseline.json`. *(satisfies: Performance budgets)*
+- [ ] 7.3 If over budget: enable `experimental.optimizePackageImports = ["@react-three/drei"]` in `apps/portfolio/next.config.*`; re-run. If still over budget, fall back to plan-B `ogl` + custom shader (proposal-documented), pause apply, route back to design.
+
+## Phase 8 — Rollout
+
+- [ ] 8.1 Land PR with `NEXT_PUBLIC_HERO_LIQUID="false"` default. Reviewers verify legacy hero unchanged on staging.
+- [ ] 8.2 Enable flag in preview deployment. Manual QA + Lighthouse comparison vs baseline.
+- [ ] 8.3 Flip flag in production. Monitor RUM (LCP/INP/CLS) for 48h.
+- [ ] 8.4 Cleanup PR: remove `HeroFragment` + flag + legacy i18n keys (Phase 4 of design migration). Out of scope for THIS change but tracked here for traceability.
+
+## Parallelism map
+
+- **Sequential boundary**: Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6 → Phase 7 → Phase 8.
+- **Parallelizable within Phase 3**: 3.1–3.2 ↔ 3.3–3.4 ↔ 3.5–3.7 (different files, different test suites).
+- **Parallelizable within Phase 6**: 6.1/6.2 ↔ 6.3/6.4 ↔ 6.5/6.6 (different Playwright projects). 6.7–6.16 must serialize after 6.1–6.6 land.
+- **Parallelizable within Phase 4**: 4.8 (i18n keys) and 4.9 (parity tests) can pair. 4.10–4.11 (JSON-LD) independent of 4.1–4.7.
+
+## Decisions to lock during apply
+
+- Final h1 wording (locked: en `Héctor Trejo Luna — Senior Software Architect`; es `Héctor Trejo Luna — Arquitecto Senior de Software`).
+- Final eyebrow microcopy (locked: en `Building digital experiences`; es `Construyendo experiencias digitales`).
+- Image asset for OG / JSON-LD (Sanity `profile.avatar` via `urlForImage(...).width(1200).height(630).url()`, fallback `/og-default.png`).
+- `LiquidGlassBackdrop` lives in `packages/ui` from day 1 (locked).
+- drei subpath import path (verify in 2.2 + 3.16).
+
+## Risks (carried into apply)
+
+1. drei subpath path may differ between drei versions → mitigated by 2.2 Context7 lookup BEFORE 3.16.
+2. `next/dynamic({ ssr:false })` placement under Next 16 RSC — must be inside a `"use client"` boundary (`HeroVisualLayer`) per 2.5; if Context7 contradicts, route back to design.
+3. Bundle cap (200 KB gz) is tight; if drei + three exceeds, plan-B `ogl` shader required (7.3).
+
+## Skill Resolution
+
+context7-strict baked into Phase 2 as preconditions; findings persisted to `sdd/hero-liquid-glass-redesign/context7` for apply + verify reuse.
+
+## Artifacts
+- engram_topic_key: `sdd/hero-liquid-glass-redesign/tasks`
+- openspec_path: `/home/hstrejoluna/Projects/hstrejoluna/openspec/changes/hero-liquid-glass-redesign/tasks.md`


### PR DESCRIPTION
Closes #34

## PR Type

- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Land the SDD planning artifacts for the upcoming hero rebuild — `explore`, `proposal`, `spec`, `design`, `tasks`.
- No production code changes; this PR is the architectural contract before any apply work begins.
- Establishes the three-layer architecture (RSC shell + always-on CSS liquid glass + capability-gated WebGL refraction), bundle budgets (≤ +5 KB gz initial / ≤ 200 KB gz lazy chunk), and the rollback flag `NEXT_PUBLIC_HERO_LIQUID`.

## Changes

| File | Change |
|------|--------|
| `openspec/changes/hero-liquid-glass-redesign/explore.md` | NEW — current-state audit (incl. SEO finding: portfolio ships zero `<h1>`) + 5-option comparison + recommended hybrid approach |
| `openspec/changes/hero-liquid-glass-redesign/proposal.md` | NEW — intent, scope, approach, affected modules, risks, rollback plan |
| `openspec/changes/hero-liquid-glass-redesign/spec.md` | NEW — 9 capability requirements with Given/When/Then scenarios + RFC 2119 keywords |
| `openspec/changes/hero-liquid-glass-redesign/design.md` | NEW — 3-layer architecture, capability gate, bundle strategy, sequence diagram, test plan |
| `openspec/changes/hero-liquid-glass-redesign/tasks.md` | NEW — 8-phase, ~85-task TDD checklist (Phase 2 = Context7 verification gate) |

## Test Plan

- [x] No code touched; nothing to run.
- [x] Markdown renders correctly on GitHub.
- [x] All five artifacts cross-reference each other and trace every spec requirement to tasks.
- [x] Spec uses RFC 2119 keywords; tasks interleave RED → GREEN → REFACTOR per Strict TDD policy.

## Contributor Checklist

- [x] Linked an approved issue (#34, `status:approved`)
- [x] Added exactly one `type:*` label (`type:docs`)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs-only change; no scripts/skills modified

## Follow-up

A separate PR series will implement the change starting at `tasks.md` Phase 1. Phase 2 must run live Context7 lookups for `@react-three/fiber`, `@react-three/drei`, `framer-motion` 12, `next-intl` 4.9, and Next.js 16 `next/dynamic({ ssr: false })` placement before any production code.