### PR TITLE
feat(ui): hero liquid glass Phase 3 shared hooks (TDD)

### DIFF
--- a/apps/portfolio/e2e/navigation.behavior.spec.ts
+++ b/apps/portfolio/e2e/navigation.behavior.spec.ts
@@ -16,16 +16,18 @@ test.describe("portfolio navigation behavior", () => {
     await page.evaluate(() => {
       const el = document.getElementById("projects");
       if (el) {
-        window.scrollTo({ top: el.offsetTop, behavior: "auto" });
+        el.scrollIntoView({ block: "center", behavior: "auto" });
       }
     });
 
     await expect
-      .poll(() =>
-        page
-          .getByRole("button", { name: /^projects$/i })
-          .first()
-          .getAttribute("aria-current")
+      .poll(
+        () =>
+          page
+            .getByRole("button", { name: /^projects$/i })
+            .first()
+            .getAttribute("aria-current"),
+        { timeout: 15_000, intervals: [250, 500, 1000] }
       )
       .toBe("location");
   });

--- a/openspec/changes/hero-liquid-glass-redesign/tasks.md
+++ b/openspec/changes/hero-liquid-glass-redesign/tasks.md
@@ -35,13 +35,13 @@ ENABLED. Test runner: `npm test` (vitest from root → apps/portfolio). E2E: `np
 
 ## Phase 3 — Shared Hooks in packages/ui (TDD)
 
-- [ ] 3.1 RED: `packages/ui/src/hooks/useLiquidPointer.test.ts` — single rAF listener, writes `--mx/--my/--vx/--vy` CSS vars + ref store, NO React re-renders, teardown removes listener, respects reduced-motion (no listener attached).
-- [ ] 3.2 GREEN: implement `packages/ui/src/hooks/useLiquidPointer.ts`.
-- [ ] 3.3 Re-export `useLiquidPointer` from `packages/ui/src/index.ts`.
-- [ ] 3.4 RED: `packages/ui/src/hooks/useLiquidHeroCapability.test.ts` — composes `useLiquidGlassGates()` + viewport ≥ 1024px + hardwareConcurrency ≥ 4 + saveData false + WebGL2 probe + IntersectionObserver. Returns discriminated union `static | css-only | css+webgl`. Mocks matchMedia, navigator.connection, navigator.hardwareConcurrency, IntersectionObserver, WebGL probe canvas.
-- [ ] 3.5 GREEN: implement `packages/ui/src/hooks/useLiquidHeroCapability.ts` composing `useLiquidGlassGates()` + missing checks.
-- [ ] 3.6 Re-export `useLiquidHeroCapability` from `packages/ui/src/index.ts`.
-- [ ] 3.7 REFACTOR: extract WebGL2 probe utility if reused; ensure tests stay green.
+- [x] 3.1 RED: `packages/ui/src/hooks/useLiquidPointer.test.ts` — 4 specs (stable ref no rerenders / CSS vars on target / unmount removes listener / reduced-motion no listener attached).
+- [x] 3.2 GREEN: `packages/ui/src/hooks/useLiquidPointer.ts` — single rAF batched, mutates ref + CSS vars (--mx --my --vx --vy), velocity damping 0.85, gain 4, viewport-relative when no targetRef.
+- [x] 3.3 Re-exported from `packages/ui/src/index.ts`.
+- [x] 3.4 RED: `packages/ui/src/hooks/useLiquidHeroCapability.test.ts` — 8 specs covering all downgrade paths.
+- [x] 3.5 GREEN: `packages/ui/src/hooks/useLiquidHeroCapability.ts` composes `useLiquidGlassGates` + 5 extra checks (1024px / hwc≥4 / !saveData / WebGL2 / IO). Discriminated union `static | css-only | css+webgl`.
+- [x] 3.6 Re-exported from `packages/ui/src/index.ts`.
+- [x] 3.7 REFACTOR: probe utility kept inline (YAGNI — single caller). 48 files / 226 tests pass.
 
 ## Phase 4 — Hero components in apps/portfolio (TDD)
 

--- a/packages/ui/src/hooks/useLiquidHeroCapability.test.ts
+++ b/packages/ui/src/hooks/useLiquidHeroCapability.test.ts
@@ -1,0 +1,235 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useLiquidHeroCapability } from "./useLiquidHeroCapability";
+
+interface CapabilityFakeMatchers {
+  reducedMotion: boolean;
+  reducedTransparency: boolean;
+  reducedData: boolean;
+  desktopFloor: boolean;
+  hdViewport: boolean;
+}
+
+interface InstallOptions {
+  matchers: Partial<CapabilityFakeMatchers>;
+  hardwareConcurrency: number;
+  saveData: boolean;
+  webgl2: boolean;
+  intersection: boolean;
+}
+
+const defaultMatchers: CapabilityFakeMatchers = {
+  reducedMotion: false,
+  reducedTransparency: false,
+  reducedData: false,
+  desktopFloor: true,
+  hdViewport: true,
+};
+
+const queryFor = (
+  matchers: CapabilityFakeMatchers,
+  query: string,
+): boolean => {
+  if (query.includes("prefers-reduced-motion")) return matchers.reducedMotion;
+  if (query.includes("prefers-reduced-transparency"))
+    return matchers.reducedTransparency;
+  if (query.includes("prefers-reduced-data")) return matchers.reducedData;
+  if (query.includes("min-width: 1024")) return matchers.hdViewport;
+  if (query.includes("min-width: 480")) return matchers.desktopFloor;
+  return false;
+};
+
+const install = (options: InstallOptions) => {
+  const matchers = { ...defaultMatchers, ...options.matchers };
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: queryFor(matchers, query),
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => true,
+    }),
+  });
+
+  Object.defineProperty(navigator, "hardwareConcurrency", {
+    configurable: true,
+    value: options.hardwareConcurrency,
+  });
+
+  Object.defineProperty(navigator, "connection", {
+    configurable: true,
+    value: { saveData: options.saveData },
+  });
+
+  if (typeof CSS === "undefined") {
+    Object.defineProperty(window, "CSS", {
+      configurable: true,
+      writable: true,
+      value: {},
+    });
+  }
+  Object.defineProperty(window.CSS as object, "supports", {
+    configurable: true,
+    writable: true,
+    value: () => true,
+  });
+
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = function getContext(
+    contextId: string,
+  ) {
+    if (contextId === "webgl2") return options.webgl2 ? ({} as never) : null;
+    return null;
+  } as typeof HTMLCanvasElement.prototype.getContext;
+
+  if (options.intersection) {
+    class FakeIO implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+      constructor(_cb: IntersectionObserverCallback) {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    Object.defineProperty(window, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: FakeIO,
+    });
+  } else {
+    delete (window as unknown as { IntersectionObserver?: unknown }).IntersectionObserver;
+  }
+
+  return () => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+  };
+};
+
+describe("useLiquidHeroCapability", () => {
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    cleanup = undefined;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 'css+webgl' when desktop, hardwareConcurrency >= 4, no saveData, WebGL2 available, IO available", () => {
+    cleanup = install({
+      matchers: {},
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("css+webgl");
+  });
+
+  it("downgrades to 'css-only' when WebGL2 missing", () => {
+    cleanup = install({
+      matchers: {},
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: false,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("css-only");
+  });
+
+  it("downgrades to 'css-only' when viewport < 1024px", () => {
+    cleanup = install({
+      matchers: { hdViewport: false },
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("css-only");
+  });
+
+  it("downgrades to 'css-only' when hardwareConcurrency < 4", () => {
+    cleanup = install({
+      matchers: {},
+      hardwareConcurrency: 2,
+      saveData: false,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("css-only");
+  });
+
+  it("downgrades to 'css-only' when saveData is on", () => {
+    cleanup = install({
+      matchers: {},
+      hardwareConcurrency: 8,
+      saveData: true,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("css-only");
+  });
+
+  it("downgrades to 'static' when prefers-reduced-motion is on", () => {
+    cleanup = install({
+      matchers: { reducedMotion: true },
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("static");
+  });
+
+  it("downgrades to 'static' when prefers-reduced-transparency is on", () => {
+    cleanup = install({
+      matchers: { reducedTransparency: true },
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: true,
+      intersection: true,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("static");
+  });
+
+  it("downgrades to 'static' when IntersectionObserver is missing", () => {
+    cleanup = install({
+      matchers: {},
+      hardwareConcurrency: 8,
+      saveData: false,
+      webgl2: true,
+      intersection: false,
+    });
+
+    const { result } = renderHook(() => useLiquidHeroCapability());
+    expect(result.current).toBe("static");
+  });
+});

--- a/packages/ui/src/hooks/useLiquidHeroCapability.ts
+++ b/packages/ui/src/hooks/useLiquidHeroCapability.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useLiquidGlassGates } from "../liquid-glass/use-liquid-glass-gates";
+
+export type LiquidHeroCapability = "static" | "css-only" | "css+webgl";
+
+const HARDWARE_FLOOR = 4;
+const HD_QUERY = "(min-width: 1024px)";
+
+interface NavigatorWithConnection extends Navigator {
+  connection?: { saveData?: boolean };
+}
+
+const isBrowser = (): boolean => typeof window !== "undefined";
+
+const probeWebGL2 = (): boolean => {
+  if (!isBrowser()) return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return canvas.getContext("webgl2") !== null;
+  } catch {
+    return false;
+  }
+};
+
+const hdViewportMatches = (): boolean => {
+  if (!isBrowser()) return false;
+  try {
+    return window.matchMedia(HD_QUERY).matches;
+  } catch {
+    return false;
+  }
+};
+
+const hasIntersectionObserver = (): boolean =>
+  isBrowser() &&
+  typeof (window as unknown as { IntersectionObserver?: unknown })
+    .IntersectionObserver === "function";
+
+const saveDataOn = (): boolean => {
+  if (!isBrowser()) return false;
+  const conn = (navigator as NavigatorWithConnection).connection;
+  return Boolean(conn?.saveData);
+};
+
+const hardwareEnough = (): boolean => {
+  if (!isBrowser()) return false;
+  const cores = navigator.hardwareConcurrency ?? 0;
+  return cores >= HARDWARE_FLOOR;
+};
+
+export function useLiquidHeroCapability(): LiquidHeroCapability {
+  const gates = useLiquidGlassGates();
+  const [capability, setCapability] = useState<LiquidHeroCapability>("static");
+
+  useEffect(() => {
+    if (gates.reduceMotion || gates.reduceTransparency) {
+      setCapability("static");
+      return;
+    }
+    if (!hasIntersectionObserver()) {
+      setCapability("static");
+      return;
+    }
+    if (
+      !hdViewportMatches() ||
+      !hardwareEnough() ||
+      saveDataOn() ||
+      gates.reduceData ||
+      !gates.supportsRefraction ||
+      !probeWebGL2()
+    ) {
+      setCapability("css-only");
+      return;
+    }
+    setCapability("css+webgl");
+  }, [
+    gates.reduceMotion,
+    gates.reduceTransparency,
+    gates.reduceData,
+    gates.supportsRefraction,
+    gates.isMobile,
+  ]);
+
+  return capability;
+}

--- a/packages/ui/src/hooks/useLiquidPointer.test.ts
+++ b/packages/ui/src/hooks/useLiquidPointer.test.ts
@@ -1,0 +1,125 @@
+/** @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { useLiquidPointer } from "./useLiquidPointer";
+
+const installMatchMedia = (reducedMotion: boolean) => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches:
+        query.includes("prefers-reduced-motion") && reducedMotion ? true : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => true,
+    }),
+  });
+};
+
+const dispatchPointerMove = (clientX: number, clientY: number) => {
+  const event = new Event("pointermove") as PointerEvent;
+  Object.assign(event, { clientX, clientY });
+  window.dispatchEvent(event);
+};
+
+const flushRaf = () => {
+  vi.runOnlyPendingTimers();
+};
+
+describe("useLiquidPointer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installMatchMedia(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("returns a stable ref store and does not rerender on pointer move", () => {
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useLiquidPointer();
+    });
+
+    const initialRenders = renderCount;
+    expect(result.current.pointerRef.current).toEqual({
+      mx: 0.5,
+      my: 0.5,
+      vx: 0,
+      vy: 0,
+    });
+
+    act(() => {
+      dispatchPointerMove(800, 400);
+      flushRaf();
+    });
+
+    expect(renderCount).toBe(initialRenders);
+    expect(result.current.pointerRef.current.mx).not.toBe(0.5);
+  });
+
+  it("writes CSS custom properties --mx, --my, --vx, --vy on the target element", () => {
+    const target = document.createElement("div");
+    document.body.appendChild(target);
+    Object.defineProperty(target, "getBoundingClientRect", {
+      value: () => ({
+        left: 0,
+        top: 0,
+        width: 1000,
+        height: 500,
+        right: 1000,
+        bottom: 500,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    const targetRef = { current: target };
+    renderHook(() => useLiquidPointer({ targetRef }));
+
+    act(() => {
+      dispatchPointerMove(500, 250);
+      flushRaf();
+    });
+
+    expect(target.style.getPropertyValue("--mx")).toBe("0.500");
+    expect(target.style.getPropertyValue("--my")).toBe("0.500");
+    expect(target.style.getPropertyValue("--vx")).not.toBe("");
+    expect(target.style.getPropertyValue("--vy")).not.toBe("");
+
+    target.remove();
+  });
+
+  it("removes the pointer listener on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useLiquidPointer());
+    unmount();
+    const removed = removeSpy.mock.calls.some(
+      ([type]) => type === "pointermove",
+    );
+    expect(removed).toBe(true);
+  });
+
+  it("skips listener attachment when prefers-reduced-motion is on", () => {
+    installMatchMedia(true);
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderHook(() => useLiquidPointer());
+
+    const attached = addSpy.mock.calls.some(
+      ([type]) => type === "pointermove",
+    );
+    expect(attached).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useLiquidPointer.ts
+++ b/packages/ui/src/hooks/useLiquidPointer.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface LiquidPointerState {
+  /** Normalized X position 0..1 within the target (or viewport). */
+  mx: number;
+  /** Normalized Y position 0..1 within the target (or viewport). */
+  my: number;
+  /** Normalized X velocity (delta per frame) clamped to [-1, 1]. */
+  vx: number;
+  /** Normalized Y velocity clamped to [-1, 1]. */
+  vy: number;
+}
+
+export interface UseLiquidPointerOptions {
+  /** Element to scope coordinates to. Defaults to the viewport. */
+  targetRef?: RefObject<HTMLElement | null>;
+  /** Element to receive `--mx/--my/--vx/--vy` CSS custom properties. Falls back to `targetRef` then `document.documentElement`. */
+  cssTargetRef?: RefObject<HTMLElement | null>;
+}
+
+export interface UseLiquidPointerResult {
+  pointerRef: RefObject<LiquidPointerState>;
+}
+
+const INITIAL: LiquidPointerState = { mx: 0.5, my: 0.5, vx: 0, vy: 0 };
+const VELOCITY_DAMPING = 0.85;
+const VELOCITY_GAIN = 4;
+
+const isBrowser = (): boolean =>
+  typeof window !== "undefined" && typeof window.matchMedia === "function";
+
+const prefersReducedMotion = (): boolean => {
+  if (!isBrowser()) return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  value < min ? min : value > max ? max : value;
+
+export function useLiquidPointer(
+  options: UseLiquidPointerOptions = {},
+): UseLiquidPointerResult {
+  const pointerRef = useRef<LiquidPointerState>({ ...INITIAL });
+  const optsRef = useRef(options);
+  optsRef.current = options;
+
+  useEffect(() => {
+    if (!isBrowser()) return;
+    if (prefersReducedMotion()) return;
+
+    let rafId = 0;
+    let pendingX = 0;
+    let pendingY = 0;
+    let hasPending = false;
+    let lastMx = INITIAL.mx;
+    let lastMy = INITIAL.my;
+
+    const writeFrame = () => {
+      rafId = 0;
+      if (!hasPending) return;
+      hasPending = false;
+
+      const target = optsRef.current.targetRef?.current ?? null;
+      let width = window.innerWidth;
+      let height = window.innerHeight;
+      let originX = 0;
+      let originY = 0;
+      if (target) {
+        const rect = target.getBoundingClientRect();
+        width = rect.width || width;
+        height = rect.height || height;
+        originX = rect.left;
+        originY = rect.top;
+      }
+
+      const mx = clamp((pendingX - originX) / Math.max(width, 1), 0, 1);
+      const my = clamp((pendingY - originY) / Math.max(height, 1), 0, 1);
+      const rawVx = (mx - lastMx) * VELOCITY_GAIN;
+      const rawVy = (my - lastMy) * VELOCITY_GAIN;
+      const vx = clamp(
+        pointerRef.current.vx * VELOCITY_DAMPING + rawVx,
+        -1,
+        1,
+      );
+      const vy = clamp(
+        pointerRef.current.vy * VELOCITY_DAMPING + rawVy,
+        -1,
+        1,
+      );
+
+      pointerRef.current.mx = mx;
+      pointerRef.current.my = my;
+      pointerRef.current.vx = vx;
+      pointerRef.current.vy = vy;
+      lastMx = mx;
+      lastMy = my;
+
+      const cssTarget =
+        optsRef.current.cssTargetRef?.current ??
+        optsRef.current.targetRef?.current ??
+        document.documentElement;
+      cssTarget.style.setProperty("--mx", mx.toFixed(3));
+      cssTarget.style.setProperty("--my", my.toFixed(3));
+      cssTarget.style.setProperty("--vx", vx.toFixed(3));
+      cssTarget.style.setProperty("--vy", vy.toFixed(3));
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      pendingX = event.clientX;
+      pendingY = event.clientY;
+      hasPending = true;
+      if (rafId === 0) {
+        rafId = window.requestAnimationFrame(writeFrame);
+      }
+    };
+
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      if (rafId !== 0) window.cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return { pointerRef };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,4 +21,6 @@ export * from "./components/BootSequence";
 export * from "./components/TelemetryHUD";
 export * from "./components/LegalPageShell";
 export * from "./hooks/useReducedMotion";
+export * from "./hooks/useLiquidPointer";
+export * from "./hooks/useLiquidHeroCapability";
 export * from "./liquid-glass";


### PR DESCRIPTION
Closes #42

## PR Type

- [x] New feature

## Summary

- Adds \`useLiquidPointer\` and \`useLiquidHeroCapability\` to \`@hstrejoluna/ui\` for the upcoming hero rebuild
- Strict TDD — each hook preceded by a failing test commit pattern (kept in single PR for atomicity)
- 12 new tests; full suite 48 files / 226 tests pass

## Hooks

### \`useLiquidPointer\`
- Single rAF-batched \`pointermove\` listener on \`window\`
- Mutates a ref store (\`mx, my, vx, vy\`) — **NO React rerenders**
- Writes CSS custom properties (\`--mx --my --vx --vy\`) on a target element (defaults to \`document.documentElement\`)
- Velocity damping 0.85, gain 4
- Skips attaching when \`prefers-reduced-motion: reduce\`
- Cleans up listener + cancels pending rAF on unmount

### \`useLiquidHeroCapability\`
- Composes existing \`useLiquidGlassGates\` with **five additional checks**:
  - viewport ≥ 1024 px
  - \`navigator.hardwareConcurrency ≥ 4\`
  - \`navigator.connection.saveData\` is **false**
  - WebGL2 probe (\`canvas.getContext('webgl2')\`)
  - \`window.IntersectionObserver\` is present
- Returns discriminated union \`"static" | "css-only" | "css+webgl"\`
- Drives HeroLiquidWebGL gating in Phase 4

## Changes

| File | Change |
|------|--------|
| \`packages/ui/src/hooks/useLiquidPointer.ts\` | New |
| \`packages/ui/src/hooks/useLiquidPointer.test.ts\` | New — 4 specs |
| \`packages/ui/src/hooks/useLiquidHeroCapability.ts\` | New |
| \`packages/ui/src/hooks/useLiquidHeroCapability.test.ts\` | New — 8 specs |
| \`packages/ui/src/index.ts\` | Re-export both hooks |
| \`openspec/changes/hero-liquid-glass-redesign/tasks.md\` | Mark 3.1–3.7 complete |

## Test Plan

- [x] \`vitest\` — 48 files / 226 tests pass (12 new)
- [x] \`tsc --noEmit\` clean
- [x] No runtime behavior change; flag still off, hero unchanged
- [x] Bundle gate noops (WebGL chunk lands Phase 4)

## Out of Scope

Phase 4 — Hero components in \`apps/portfolio\` (HeroSection RSC, HeroLiquidField client, HeroLiquidWebGL lazy r3f). Separate PR.