### PR TITLE
feat(portfolio): hero liquid glass Phase 4B — HeroLiquidField visual orchestration

### DIFF
--- a/apps/portfolio/components/fragments/HeroLiquidField.test.tsx
+++ b/apps/portfolio/components/fragments/HeroLiquidField.test.tsx
@@ -1,0 +1,361 @@
+/// <reference types="vitest/globals" />
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi, beforeEach, beforeAll } from "vitest";
+
+// ────────────────────────────────────────────────────────────────────
+// Hoisted mock variables (must be hoisted to work with vi.mock)
+// ────────────────────────────────────────────────────────────────────
+const {
+  sessionStorageGetItem,
+  sessionStorageSetItem,
+  sessionStorageClear,
+  mockUseLiquidPointer,
+  mockUseLiquidHeroCapability,
+  mockUseDisplacementScaleAnimation,
+  mockDynamicDefault,
+} = vi.hoisted(() => {
+  const sessionStore: Record<string, string> = {};
+
+  return {
+    sessionStorageGetItem: vi.fn((key: string) => sessionStore[key] ?? null),
+    sessionStorageSetItem: vi.fn((key: string, value: string) => {
+      sessionStore[key] = value;
+    }),
+    sessionStorageClear: vi.fn(() => {
+      Object.keys(sessionStore).forEach((k) => delete sessionStore[k]);
+    }),
+    mockUseLiquidPointer: vi.fn(),
+    mockUseLiquidHeroCapability: vi.fn(),
+    mockUseDisplacementScaleAnimation: vi.fn(),
+    mockDynamicDefault: vi.fn(() =>
+      vi.fn(() => <div data-testid="hero-liquid-webgl">WebGL Mock</div>),
+    ),
+  };
+});
+
+// ────────────────────────────────────────────────────────────────────
+// sessionStorage mock — defined now but installed in beforeAll
+// ────────────────────────────────────────────────────────────────────
+const sessionStorageMock = {
+  getItem: sessionStorageGetItem,
+  setItem: sessionStorageSetItem,
+  removeItem: vi.fn(),
+  clear: sessionStorageClear,
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Mock @hstrejoluna/ui
+// ────────────────────────────────────────────────────────────────────
+vi.mock("@hstrejoluna/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@hstrejoluna/ui")>();
+  return {
+    ...actual,
+    useLiquidPointer: mockUseLiquidPointer,
+    useLiquidHeroCapability: mockUseLiquidHeroCapability,
+    useDisplacementScaleAnimation: mockUseDisplacementScaleAnimation,
+    useReducedMotion: vi.fn(() => false),
+  };
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Mock framer-motion (NO spread — motion.* usage would fail)
+// ────────────────────────────────────────────────────────────────────
+vi.mock("framer-motion", () => {
+  const noopUnsub = vi.fn();
+  return {
+    useScroll: () => ({
+      scrollYProgress: { get: () => 0, on: vi.fn(() => noopUnsub) },
+      scrollY: { get: () => 0, on: vi.fn(() => noopUnsub) },
+      scrollXProgress: { get: () => 0, on: vi.fn(() => noopUnsub) },
+      scrollX: { get: () => 0, on: vi.fn(() => noopUnsub) },
+    }),
+    useTransform: (_input: unknown, _range: unknown, output: unknown) =>
+      Array.isArray(output)
+        ? { get: () => output[0], on: vi.fn(() => noopUnsub) }
+        : { get: () => 0, on: vi.fn(() => noopUnsub) },
+    useReducedMotion: vi.fn(() => false),
+    LazyMotion: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    m: {
+      div: ({
+        children,
+        style,
+        ref,
+        ...props
+      }: React.PropsWithChildren<
+        Record<string, unknown> & { ref?: React.Ref<HTMLDivElement> }
+      >) => (
+        <div
+          {...(props as React.HTMLAttributes<HTMLDivElement>)}
+          style={style as React.CSSProperties}
+          ref={ref}
+        >
+          {children}
+        </div>
+      ),
+    },
+  };
+});
+
+// ────────────────────────────────────────────────────────────────────
+// Mock next/dynamic
+// ────────────────────────────────────────────────────────────────────
+vi.mock("next/dynamic", () => ({
+  default: mockDynamicDefault,
+}));
+
+// ────────────────────────────────────────────────────────────────────
+// Import after mocks
+// ────────────────────────────────────────────────────────────────────
+import { HeroLiquidField } from "./HeroLiquidField";
+import type { LiquidHeroCapability } from "@hstrejoluna/ui";
+
+// ────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────
+const setCapability = (cap: LiquidHeroCapability): void => {
+  mockUseLiquidHeroCapability.mockReturnValue(cap);
+};
+
+const resetAll = (): void => {
+  // Clear only per-test mocks — NOT mockDynamicDefault (called at module level)
+  mockUseLiquidPointer.mockClear();
+  mockUseLiquidHeroCapability.mockClear();
+  mockUseDisplacementScaleAnimation.mockClear();
+  sessionStorageGetItem.mockClear();
+  sessionStorageSetItem.mockClear();
+  sessionStorageClear.mockClear();
+
+  // Manually clear session storage via our hoisted clear fn
+  sessionStorageMock.clear();
+  setCapability("css+webgl");
+  mockUseLiquidPointer.mockReturnValue({
+    pointerRef: { current: { mx: 0.5, my: 0.5, vx: 0, vy: 0 } },
+  });
+};
+
+// ────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────
+describe("HeroLiquidField — Visual orchestration layer", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "sessionStorage", {
+      value: sessionStorageMock,
+      writable: true,
+      configurable: true,
+    });
+    HTMLCanvasElement.prototype.getContext = vi.fn();
+  });
+
+  beforeEach(() => {
+    resetAll();
+  });
+
+  // ── Assertion 1: aria-hidden wrapper ───────────────────────
+  it("1. wraps decoration in aria-hidden='true' element", () => {
+    const { container } = render(<HeroLiquidField />);
+    const wrapper = container.firstElementChild;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!).toHaveAttribute("aria-hidden", "true");
+  });
+
+  // ── Assertion 2: three blob divs styled by CSS vars ────────
+  it("2a. renders exactly three blob elements", () => {
+    const { container } = render(<HeroLiquidField />);
+    const blobs = container.querySelectorAll(
+      '[class*="hero-blob"][class*="blob-"]',
+    );
+    expect(blobs.length).toBe(3);
+  });
+
+  it("2b. blob elements reference CSS custom properties (--mx, --my)", () => {
+    const { container } = render(<HeroLiquidField />);
+    const blobs = container.querySelectorAll(
+      '[class*="hero-blob"][class*="blob-"]',
+    );
+    expect(blobs.length).toBeGreaterThanOrEqual(3);
+    blobs.forEach((blob) => {
+      const el = blob as HTMLElement;
+      const styleCss =
+        typeof el.style.cssText === "string" ? el.style.cssText : "";
+      const hasCssVar =
+        styleCss.includes("--mx") ||
+        styleCss.includes("--my") ||
+        styleCss.includes("--vx") ||
+        styleCss.includes("--vy");
+      expect(hasCssVar).toBe(true);
+    });
+  });
+
+  // ── Assertion 3: LiquidGlass variant="panel" card ──────────
+  it("3. renders <LiquidGlass variant='panel'> for backdrop", () => {
+    const { container } = render(<HeroLiquidField />);
+    const glass = container.querySelector("[data-lg-variant='panel']");
+    expect(glass).not.toBeNull();
+  });
+
+  // ── Assertion 4: subscribes to useLiquidPointer ────────────
+  it("4. calls useLiquidPointer on mount with correct options", () => {
+    render(<HeroLiquidField />);
+    expect(mockUseLiquidPointer).toHaveBeenCalledTimes(1);
+    const args = mockUseLiquidPointer.mock.calls[0]?.[0];
+    expect(args).toBeDefined();
+    expect(args).toHaveProperty("targetRef");
+    expect(args).toHaveProperty("cssTargetRef");
+  });
+
+  // ── Assertion 5: displacement via useDisplacementScaleAnimation ──
+  it("5a. calls useDisplacementScaleAnimation on mount", () => {
+    render(<HeroLiquidField />);
+    expect(mockUseDisplacementScaleAnimation).toHaveBeenCalled();
+  });
+
+  it("5b. useDisplacementScaleAnimation receives a ref and a MotionValue", () => {
+    render(<HeroLiquidField />);
+    const calls = mockUseDisplacementScaleAnimation.mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    const firstArg = calls[0]?.[0];
+    expect(firstArg).toBeDefined();
+    expect(firstArg).toHaveProperty("current");
+    const secondArg = calls[0]?.[1];
+    expect(secondArg).toBeDefined();
+    expect(typeof secondArg?.get).toBe("function");
+    expect(typeof secondArg?.on).toBe("function");
+  });
+
+  // ── Assertion 6: entrance-burst tween plays once ───────────
+  it("6a. sets sessionStorage flag on first mount to prevent replay", () => {
+    render(<HeroLiquidField />);
+    const setItemCalls = sessionStorageSetItem.mock.calls.filter(
+      (call: string[]) => call[0] === "hero-burst-played",
+    );
+    expect(setItemCalls.length).toBe(1);
+    expect(setItemCalls[0]?.[1]).toBe("1");
+  });
+
+  it("6b. does NOT set sessionStorage flag on second mount (already played)", () => {
+    // Pre-populate sessionStorage via the hoisted store
+    sessionStorageGetItem.mockImplementation((key: string) =>
+      key === "hero-burst-played" ? "1" : null,
+    );
+
+    render(<HeroLiquidField />);
+    const setItemCalls = sessionStorageSetItem.mock.calls.filter(
+      (call: string[]) => call[0] === "hero-burst-played",
+    );
+    expect(setItemCalls.length).toBe(0);
+  });
+
+  it("6c. burst guard is suppressed when capability is not 'css+webgl'", () => {
+    setCapability("css-only");
+    render(<HeroLiquidField />);
+    const setItemCalls = sessionStorageSetItem.mock.calls.filter(
+      (call: string[]) => call[0] === "hero-burst-played",
+    );
+    expect(setItemCalls.length).toBe(0);
+  });
+
+  // ── Assertion 7: freezes under reduced-motion (static profile) ──
+  it("7a. renders frozen blobs when capability is 'static'", () => {
+    setCapability("static");
+    const { container } = render(<HeroLiquidField />);
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!).toHaveAttribute("aria-hidden", "true");
+
+    const blobs = container.querySelectorAll(
+      '[class*="hero-blob"][class*="blob-"]',
+    );
+    expect(blobs.length).toBe(3);
+
+    const hasFrozenBlob = Array.from(blobs).some((blob) => {
+      const style = (blob as HTMLElement).style;
+      return (
+        style.animation === "none" ||
+        style.animationPlayState === "paused" ||
+        style.animationName === "none"
+      );
+    });
+    expect(hasFrozenBlob).toBe(true);
+  });
+
+  it("7b. does NOT render WebGL when capability is 'static'", () => {
+    setCapability("static");
+    render(<HeroLiquidField />);
+    expect(screen.queryByTestId("hero-liquid-webgl")).not.toBeInTheDocument();
+  });
+
+  // ── Assertion 8: uses m.* from framer-motion ───────────────
+  it("8. renders successfully using m.div from framer-motion", () => {
+    const { container } = render(<HeroLiquidField />);
+    expect(container.firstElementChild).not.toBeNull();
+    expect(container.firstElementChild).toHaveAttribute("aria-hidden", "true");
+  });
+
+  // ── Assertion 9: calls useLiquidHeroCapability ─────────────
+  it("9a. calls useLiquidHeroCapability to determine visual profile", () => {
+    render(<HeroLiquidField />);
+    expect(mockUseLiquidHeroCapability).toHaveBeenCalledTimes(1);
+  });
+
+  it("9b. renders WebGL when capability is 'css+webgl'", () => {
+    setCapability("css+webgl");
+    render(<HeroLiquidField />);
+    expect(screen.getByTestId("hero-liquid-webgl")).toBeInTheDocument();
+  });
+
+  it("9c. does NOT render WebGL when capability is 'css-only'", () => {
+    setCapability("css-only");
+    const { container } = render(<HeroLiquidField />);
+    expect(screen.queryByTestId("hero-liquid-webgl")).not.toBeInTheDocument();
+    expect(container.querySelector("[data-lg-variant='panel']")).not.toBeNull();
+  });
+
+  it("9d. static profile: blobs, glass card, no WebGL", () => {
+    setCapability("static");
+    const { container } = render(<HeroLiquidField />);
+
+    const blobs = container.querySelectorAll(
+      '[class*="hero-blob"][class*="blob-"]',
+    );
+    expect(blobs.length).toBe(3);
+
+    expect(container.querySelector("[data-lg-variant='panel']")).not.toBeNull();
+
+    expect(screen.queryByTestId("hero-liquid-webgl")).not.toBeInTheDocument();
+  });
+
+  // ── Assertion 10: lazy HeroLiquidWebGL via next/dynamic ────
+  it("10a. renders lazy WebGL component when capability is 'css+webgl'", () => {
+    render(<HeroLiquidField />);
+    expect(screen.getByTestId("hero-liquid-webgl")).toBeInTheDocument();
+  });
+
+  it("10b. does NOT render WebGL when capability is 'css-only'", () => {
+    setCapability("css-only");
+    render(<HeroLiquidField />);
+    expect(screen.queryByTestId("hero-liquid-webgl")).not.toBeInTheDocument();
+  });
+
+  it("10c. does NOT render WebGL when capability is 'static'", () => {
+    setCapability("static");
+    render(<HeroLiquidField />);
+    expect(screen.queryByTestId("hero-liquid-webgl")).not.toBeInTheDocument();
+  });
+
+  it("10d. next/dynamic is called with ssr:false for WebGL import", () => {
+    render(<HeroLiquidField />);
+    expect(mockDynamicDefault).toHaveBeenCalled();
+    const allCalls = mockDynamicDefault.mock.calls as unknown[][];
+    expect(allCalls.length).toBeGreaterThanOrEqual(1);
+    const firstCall = allCalls[0];
+    expect(firstCall).toBeDefined();
+    if (firstCall && firstCall.length >= 2) {
+      const config = firstCall[1] as { ssr?: boolean };
+      expect(config).toHaveProperty("ssr", false);
+    }
+  });
+});

--- a/apps/portfolio/components/fragments/HeroLiquidField.tsx
+++ b/apps/portfolio/components/fragments/HeroLiquidField.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useRef, useEffect, type ReactElement } from "react";
+import dynamic from "next/dynamic";
+import {
+  useLiquidPointer,
+  useLiquidHeroCapability,
+  useDisplacementScaleAnimation,
+  useReducedMotion,
+  LiquidGlass,
+  LG_FILTER_IDS,
+} from "@hstrejoluna/ui";
+import { m, useScroll, useTransform, type MotionValue } from "framer-motion";
+import { getScrollStore } from "./hero-uniform-store";
+
+// Lazy-load the WebGL layer inside the client boundary (design §5 / §13.1)
+const HeroLiquidWebGLLazy = dynamic(
+  () =>
+    import("./HeroLiquidWebGL").then((mod) => ({
+      default: mod.HeroLiquidWebGL,
+    })),
+  { ssr: false },
+);
+
+/**
+ * HeroLiquidField — Client-side liquid glass visual layer.
+ *
+ * Renders three radial-gradient blob divs driven by CSS custom properties
+ * from `useLiquidPointer`, a `<LiquidGlass variant="panel">` frosted card
+ * behind the text content, and conditionally lazy-loads the WebGL
+ * refraction layer when capability permits.
+ *
+ * Design contract: spec § "Liquid glass CSS layer", design §2.
+ */
+export const HeroLiquidField = (): ReactElement => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const displacementRef = useRef<SVGFEDisplacementMapElement>(null);
+  const isReducedMotion = useReducedMotion();
+  const capability = useLiquidHeroCapability();
+
+  // Cursor → CSS vars (zero React re-renders via ref store)
+  useLiquidPointer({
+    targetRef: containerRef,
+    cssTargetRef: containerRef,
+  });
+
+  // ── Entrance burst guard — prevent replay on remount (design §3.3) ──
+  const burstPlayed = useRef(false);
+  useEffect(() => {
+    if (capability !== "css+webgl" || burstPlayed.current) return;
+    const key = "hero-burst-played";
+    if (typeof window !== "undefined" && window.sessionStorage.getItem(key))
+      return;
+    burstPlayed.current = true;
+    try {
+      window.sessionStorage.setItem(key, "1");
+    } catch {
+      // sessionStorage may be unavailable (SSR / private browsing)
+    }
+    // Burst tween handled inside HeroLiquidWebGL's useFrame
+  }, [capability]);
+
+  // Scroll → distortion via framer-motion useScroll
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ["start start", "end start"],
+  });
+
+  const distortionScale = useTransform(
+    scrollYProgress,
+    [0, 1],
+    isReducedMotion ? [0, 0] : [0, 60],
+  );
+
+  // Bind scroll-driven scale to the displacement map
+  useDisplacementScaleAnimation(
+    displacementRef,
+    distortionScale as MotionValue<number>,
+  );
+
+  // ── Scroll → scrollStore (consumed by HeroLiquidWebGL useFrame) ────
+  useEffect(() => {
+    const scrollStore = getScrollStore();
+    // Subscribe to scrollYProgress changes — framer-motion MotionValue.on()
+    // returns an unsubscribe function
+    const unsubscribe = scrollYProgress.on("change", (value: number) => {
+      scrollStore.set(value);
+    });
+    return unsubscribe;
+  }, [scrollYProgress]);
+
+  // ── Static profile: frozen blobs, no animations, no WebGL ──────────
+  if (capability === "static") {
+    return (
+      <div
+        ref={containerRef}
+        aria-hidden="true"
+        className="absolute inset-0 z-0 overflow-hidden pointer-events-none"
+      >
+        {/* SVG Goo filter (still needed for LC static distortion) */}
+        <svg className="absolute w-0 h-0" aria-hidden="true">
+          <defs>
+            <filter
+              id={LG_FILTER_IDS.gooey}
+              x="-20%"
+              y="-20%"
+              width="140%"
+              height="140%"
+            >
+              <feGaussianBlur
+                in="SourceGraphic"
+                stdDeviation="10"
+                result="blur"
+              />
+              <feColorMatrix
+                in="blur"
+                mode="matrix"
+                values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
+                result="gooey"
+              />
+              <feComposite in="SourceGraphic" in2="gooey" operator="atop" />
+            </filter>
+          </defs>
+        </svg>
+
+        {/* Frozen blob layers — static positions, no cursor follow */}
+        <div
+          className="absolute inset-0"
+          style={{ filter: `url(#${LG_FILTER_IDS.gooey})` }}
+        >
+          {/* Blob 1 — primary, frozen */}
+          <div
+            className="hero-blob hero-blob-1 absolute w-[60vw] h-[60vw] max-w-[800px] max-h-[800px] rounded-full opacity-60"
+            style={{
+              background:
+                "radial-gradient(circle, rgba(255,86,55,0.3) 0%, rgba(255,86,55,0.05) 50%, transparent 70%)",
+              left: "calc(0.5 * 100% - 30vw)",
+              top: "calc(0.5 * 100% - 30vw)",
+              filter: "blur(40px)",
+              animation: "none",
+            }}
+          />
+
+          {/* Blob 2 — secondary, frozen */}
+          <div
+            className="hero-blob hero-blob-2 absolute w-[40vw] h-[40vw] max-w-[500px] max-h-[500px] rounded-full opacity-40"
+            style={{
+              background:
+                "radial-gradient(circle, rgba(209,77,255,0.2) 0%, rgba(209,77,255,0.03) 60%, transparent 80%)",
+              right: "calc(0.5 * 100% - 20vw)",
+              bottom: "calc(0.5 * 100% - 20vw)",
+              filter: "blur(50px)",
+              animation: "none",
+            }}
+          />
+
+          {/* Blob 3 — accent, frozen */}
+          <div
+            className="hero-blob hero-blob-3 absolute w-[30vw] h-[30vw] max-w-[350px] max-h-[350px] rounded-full opacity-30"
+            style={{
+              background:
+                "radial-gradient(circle, rgba(34,197,94,0.15) 0%, rgba(34,197,94,0.02) 60%, transparent 80%)",
+              left: "calc(0.5 * 100% - 20vw)",
+              bottom: "calc(0.5 * 100% - 25vw)",
+              filter: "blur(35px)",
+              animation: "none",
+            }}
+          />
+        </div>
+
+        {/* Glass card backdrop — always present */}
+        <LiquidGlass
+          variant="panel"
+          intensity="high"
+          className="absolute inset-x-4 md:inset-x-24 top-1/2 -translate-y-1/2 max-w-7xl mx-auto rounded-tr-[40px] rounded-bl-[40px] border border-white/5"
+          style={{
+            padding: "2rem",
+            minHeight: "300px",
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      aria-hidden="true"
+      className="absolute inset-0 z-0 overflow-hidden pointer-events-none"
+    >
+      {/* SVG Goo + Refraction filter definitions */}
+      <svg className="absolute w-0 h-0" aria-hidden="true">
+        <defs>
+          {/* Gooey filter for blob merging */}
+          <filter
+            id={LG_FILTER_IDS.gooey}
+            x="-20%"
+            y="-20%"
+            width="140%"
+            height="140%"
+          >
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation="10"
+              result="blur"
+            />
+            <feColorMatrix
+              in="blur"
+              mode="matrix"
+              values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 18 -7"
+              result="gooey"
+            />
+            <feComposite in="SourceGraphic" in2="gooey" operator="atop" />
+          </filter>
+
+          {/* Refraction filter with scroll-bound displacement */}
+          <filter
+            id="lg-hero-refraction"
+            x="-20%"
+            y="-20%"
+            width="140%"
+            height="140%"
+            filterUnits="objectBoundingBox"
+            primitiveUnits="userSpaceOnUse"
+          >
+            <feGaussianBlur
+              in="SourceGraphic"
+              stdDeviation="0.5"
+              result="blur"
+            />
+            <feDisplacementMap
+              ref={displacementRef}
+              in="blur"
+              in2="gooey"
+              scale={9}
+              xChannelSelector="R"
+              yChannelSelector="G"
+              result="displaced"
+            />
+            <feGaussianBlur
+              in="displaced"
+              stdDeviation="0.8"
+              result="softened"
+            />
+          </filter>
+        </defs>
+      </svg>
+
+      {/* Three animated blob layers — driven by CSS vars --mx/--my */}
+      <div
+        className="absolute inset-0"
+        style={{
+          filter: `url(#${LG_FILTER_IDS.gooey})`,
+          animationPlayState: isReducedMotion ? "paused" : "running",
+        }}
+      >
+        {/* Blob 1 — primary */}
+        <m.div
+          className="hero-blob hero-blob-1 absolute w-[60vw] h-[60vw] max-w-[800px] max-h-[800px] rounded-full opacity-60"
+          style={{
+            background:
+              "radial-gradient(circle, rgba(255,86,55,0.3) 0%, rgba(255,86,55,0.05) 50%, transparent 70%)",
+            left: `calc(var(--mx, 0.5) * 100% - 30vw)`,
+            top: `calc(var(--my, 0.5) * 100% - 30vw)`,
+            filter: "blur(40px)",
+            animation: isReducedMotion
+              ? "none"
+              : "hero-blob-drift-1 8s ease-in-out infinite alternate",
+          }}
+        />
+
+        {/* Blob 2 — secondary */}
+        <m.div
+          className="hero-blob hero-blob-2 absolute w-[40vw] h-[40vw] max-w-[500px] max-h-[500px] rounded-full opacity-40"
+          style={{
+            background:
+              "radial-gradient(circle, rgba(209,77,255,0.2) 0%, rgba(209,77,255,0.03) 60%, transparent 80%)",
+            right: `calc((1 - var(--mx, 0.5)) * 100% - 20vw)`,
+            bottom: `calc((1 - var(--my, 0.5)) * 100% - 20vw)`,
+            filter: "blur(50px)",
+            animation: isReducedMotion
+              ? "none"
+              : "hero-blob-drift-2 10s ease-in-out infinite alternate",
+          }}
+        />
+
+        {/* Blob 3 — accent */}
+        <m.div
+          className="hero-blob hero-blob-3 absolute w-[30vw] h-[30vw] max-w-[350px] max-h-[350px] rounded-full opacity-30"
+          style={{
+            background:
+              "radial-gradient(circle, rgba(34,197,94,0.15) 0%, rgba(34,197,94,0.02) 60%, transparent 80%)",
+            left: `calc(var(--mx, 0.5) * 100% - 20vw)`,
+            bottom: `calc((1 - var(--my, 0.5)) * 100% - 25vw)`,
+            filter: "blur(35px)",
+            animation: isReducedMotion
+              ? "none"
+              : "hero-blob-drift-3 12s ease-in-out infinite alternate",
+          }}
+        />
+      </div>
+
+      {/* Glass card backdrop — sits behind text, provides contrast */}
+      <LiquidGlass
+        variant="panel"
+        intensity="high"
+        className="absolute inset-x-4 md:inset-x-24 top-1/2 -translate-y-1/2 max-w-7xl mx-auto rounded-tr-[40px] rounded-bl-[40px] border border-white/5"
+        style={{
+          padding: "2rem",
+          minHeight: "300px",
+        }}
+      />
+
+      {/* WebGL refraction layer — lazy, capability-gated */}
+      {capability === "css+webgl" && <HeroLiquidWebGLLazy />}
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #45

## Summary
- Client component orchestrating CSS blobs, LiquidGlass panel, cursor reactivity
- Capability gate via useLiquidHeroCapability (static | css-only | css+webgl)
- sessionStorage burst guard, static frozen profile for reduced-motion
- Lazy-loads HeroLiquidWebGL via next/dynamic
- 21 vitest tests covering all profiles and edge cases

## Changes
| File | Change |
|------|--------|
| `apps/portfolio/components/fragments/HeroLiquidField.tsx` | New client orchestration component |
| `apps/portfolio/components/fragments/HeroLiquidField.test.tsx` | 21 tests |

## Test Plan
- [x] `npm test` — 21/21 HeroLiquidField, 280 total pass
- [x] `npx tsc --noEmit` — no new errors

## Type
- [x] New feature → `type:feature`