### PR TITLE
ci(cd): matrix deploy, buildx caching, turbo in Docker, develop cache

### DIFF
--- a/.github/workflows/cd-cloudrun.yml
+++ b/.github/workflows/cd-cloudrun.yml
@@ -27,16 +27,32 @@ env:
   CLOUD_RUN_TIMEOUT: ${{ vars.CLOUD_RUN_TIMEOUT || '60' }}
 
 jobs:
-  deploy-portfolio:
-    name: Deploy portfolio
+  deploy:
+    name: Deploy ${{ matrix.app.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    strategy:
+      matrix:
+        app:
+          - name: portfolio
+            service: ${{ vars.CLOUD_RUN_SERVICE_PORTFOLIO || 'portfolio' }}
+            image: portfolio
+            smoke_path: ${{ vars.CLOUD_RUN_SMOKE_PATH_PORTFOLIO || '/' }}
+            has_env_vars: true
+            sanity_secret: ${{ vars.CLOUD_RUN_SECRET_SANITY_API_READ_TOKEN || 'portfolio-sanity-api-read-token' }}
+          - name: maestros-del-salmon
+            service: ${{ vars.CLOUD_RUN_SERVICE_SALMON || 'maestros-del-salmon' }}
+            image: maestros-del-salmon
+            smoke_path: ${{ vars.CLOUD_RUN_SMOKE_PATH_SALMON || '/maestros-del-salmon' }}
+            has_env_vars: false
+            sanity_secret: ''
+
     env:
-      SERVICE_NAME: ${{ vars.CLOUD_RUN_SERVICE_PORTFOLIO || 'portfolio' }}
-      IMAGE_NAME: portfolio
-      SMOKE_PATH: ${{ vars.CLOUD_RUN_SMOKE_PATH_PORTFOLIO || '/' }}
-      SALMON_ORIGIN: ${{ vars.SALMON_ORIGIN || '' }}
-      SANITY_API_READ_SECRET: ${{ vars.CLOUD_RUN_SECRET_SANITY_API_READ_TOKEN || 'portfolio-sanity-api-read-token' }}
+      SERVICE_NAME: ${{ matrix.app.service }}
+      IMAGE_NAME: ${{ matrix.app.image }}
+      SMOKE_PATH: ${{ matrix.app.smoke_path }}
+      DOCKER_BUILDKIT: 1
 
     steps:
       - name: Checkout
@@ -65,12 +81,17 @@ jobs:
         if: ${{ env.ACT != 'true' }}
         run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
 
-      - name: Validate portfolio runtime env contract
+      - name: Set up Docker Buildx
         if: ${{ env.ACT != 'true' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Validate runtime env contract
+        if: ${{ env.ACT != 'true' && matrix.app.has_env_vars == true }}
         run: |
+          set -euo pipefail
           missing=()
-          [ -z "${SALMON_ORIGIN}" ] && missing+=("SALMON_ORIGIN (repo variable)")
-          [ -z "${SANITY_API_READ_SECRET}" ] && missing+=("CLOUD_RUN_SECRET_SANITY_API_READ_TOKEN (repo variable)")
+          [ -z "${SALMON_ORIGIN:-}" ] && missing+=("SALMON_ORIGIN (repo variable)")
+          [ -z "${{ matrix.app.sanity_secret }}" ] && missing+=("CLOUD_RUN_SECRET_SANITY_API_READ_TOKEN (repo variable)")
 
           if [ ${#missing[@]} -gt 0 ]; then
             echo "Missing required runtime configuration for portfolio deploy:"
@@ -78,22 +99,40 @@ jobs:
             exit 1
           fi
 
-          gcloud secrets describe "${SANITY_API_READ_SECRET}" --project "${GCP_PROJECT_ID}" > /dev/null
+          gcloud secrets describe "${{ matrix.app.sanity_secret }}" --project "${GCP_PROJECT_ID}" > /dev/null
+        env:
+          SALMON_ORIGIN: ${{ vars.SALMON_ORIGIN || '' }}
 
-      - name: Build image
+      - name: Build and push image
         if: ${{ env.ACT != 'true' }}
         run: |
+          set -euo pipefail
           IMAGE_BASE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GAR_REPOSITORY}/${IMAGE_NAME}"
           IMAGE_TAG="${IMAGE_BASE}:${GITHUB_SHA}"
           IMAGE_LATEST="${IMAGE_BASE}:latest"
-          docker build -f apps/portfolio/Dockerfile -t "${IMAGE_TAG}" -t "${IMAGE_LATEST}" .
-          docker push "${IMAGE_TAG}"
-          docker push "${IMAGE_LATEST}"
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_TAG}")"
-          echo "IMAGE_DIGEST=${DIGEST}" >> "${GITHUB_ENV}"
+          docker buildx build \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            -f "apps/${{ matrix.app.name }}/Dockerfile" \
+            -t "${IMAGE_TAG}" \
+            -t "${IMAGE_LATEST}" \
+            --push \
+            .
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE_TAG}" --format '{{ .Digest }}')"
+          echo "IMAGE_DIGEST=${IMAGE_BASE}@${DIGEST}" >> "${GITHUB_ENV}"
 
-      - name: Deploy to Cloud Run
-        if: ${{ env.ACT != 'true' }}
+      - name: Build image (act simulation)
+        if: ${{ env.ACT == 'true' }}
+        run: |
+          set -euo pipefail
+          IMAGE_BASE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID:-local-project}/${GAR_REPOSITORY}/${IMAGE_NAME}"
+          IMAGE_TAG="${IMAGE_BASE}:${GITHUB_SHA}"
+          IMAGE_LATEST="${IMAGE_BASE}:latest"
+          docker build -f "apps/${{ matrix.app.name }}/Dockerfile" -t "${IMAGE_TAG}" -t "${IMAGE_LATEST}" .
+          echo "IMAGE_DIGEST=${IMAGE_TAG}@sha256:actlocal" >> "${GITHUB_ENV}"
+
+      - name: Deploy to Cloud Run (with env vars and secrets)
+        if: ${{ env.ACT != 'true' && matrix.app.has_env_vars == true }}
         run: |
           gcloud run deploy "${SERVICE_NAME}" \
             --project "${GCP_PROJECT_ID}" \
@@ -107,68 +146,16 @@ jobs:
             --memory "${CLOUD_RUN_MEMORY}" \
             --timeout "${CLOUD_RUN_TIMEOUT}" \
             --update-env-vars "SALMON_ORIGIN=${SALMON_ORIGIN}" \
-            --set-secrets "SANITY_API_READ_TOKEN=${SANITY_API_READ_SECRET}:latest" \
+            --set-secrets "SANITY_API_READ_TOKEN=${{ matrix.app.sanity_secret }}:latest" \
             --cpu-throttling \
             --no-cpu-boost \
             --allow-unauthenticated \
             --quiet
+        env:
+          SALMON_ORIGIN: ${{ vars.SALMON_ORIGIN || '' }}
 
-      - name: Smoke check
-        if: ${{ env.ACT != 'true' }}
-        run: |
-          SERVICE_URL="$(gcloud run services describe "${SERVICE_NAME}" --project "${GCP_PROJECT_ID}" --region "${GCP_REGION}" --format='value(status.url)')"
-          curl --fail --silent --show-error "${SERVICE_URL}${SMOKE_PATH}" > /dev/null
-
-  deploy-maestros-del-salmon:
-    name: Deploy maestros-del-salmon
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      SERVICE_NAME: ${{ vars.CLOUD_RUN_SERVICE_SALMON || 'maestros-del-salmon' }}
-      IMAGE_NAME: maestros-del-salmon
-      SMOKE_PATH: ${{ vars.CLOUD_RUN_SMOKE_PATH_SALMON || '/maestros-del-salmon' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Local act simulation marker
-        if: ${{ env.ACT == 'true' }}
-        run: |
-          IMAGE_BASE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID:-local-project}/${GAR_REPOSITORY}/${IMAGE_NAME}"
-          IMAGE_TAG="${IMAGE_BASE}:${GITHUB_SHA}"
-          echo "IMAGE_DIGEST=${IMAGE_TAG}@sha256:actlocal" >> "${GITHUB_ENV}"
-          echo "ACT mode: skipping real GCP deploy steps."
-
-      - name: Authenticate to Google Cloud
-        if: ${{ env.ACT != 'true' }}
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
-
-      - name: Setup gcloud
-        if: ${{ env.ACT != 'true' }}
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker auth for Artifact Registry
-        if: ${{ env.ACT != 'true' }}
-        run: gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
-
-      - name: Build image
-        if: ${{ env.ACT != 'true' }}
-        run: |
-          IMAGE_BASE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GAR_REPOSITORY}/${IMAGE_NAME}"
-          IMAGE_TAG="${IMAGE_BASE}:${GITHUB_SHA}"
-          IMAGE_LATEST="${IMAGE_BASE}:latest"
-          docker build -f apps/maestros-del-salmon/Dockerfile -t "${IMAGE_TAG}" -t "${IMAGE_LATEST}" .
-          docker push "${IMAGE_TAG}"
-          docker push "${IMAGE_LATEST}"
-          DIGEST="$(docker inspect --format='{{index .RepoDigests 0}}' "${IMAGE_TAG}")"
-          echo "IMAGE_DIGEST=${DIGEST}" >> "${GITHUB_ENV}"
-
-      - name: Deploy to Cloud Run
-        if: ${{ env.ACT != 'true' }}
+      - name: Deploy to Cloud Run (no env vars)
+        if: ${{ env.ACT != 'true' && matrix.app.has_env_vars == false }}
         run: |
           gcloud run deploy "${SERVICE_NAME}" \
             --project "${GCP_PROJECT_ID}" \

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -47,6 +47,13 @@ jobs:
             exit 1
           fi
 
+      - name: Check develop branch existence
+        id: develop_check
+        uses: actions/cache@v4
+        with:
+          path: .github/develop-branch-marker
+          key: develop-branch-exists
+
       - name: Validate Gitflow base branch mapping
         run: |
           set -euo pipefail
@@ -59,15 +66,24 @@ jobs:
             exit 0
           fi
 
-          if gh api "repos/${OWNER}/${REPO}/branches/develop" > /dev/null 2>&1; then
+          if [ "${{ steps.develop_check.outputs.cache-hit }}" == "true" ]; then
+            echo "Cache hit: develop branch exists (cached result)."
             if [ "${BASE_BRANCH}" != "develop" ]; then
               echo "Feature/fix/chore/etc branches must target develop when develop branch exists."
               exit 1
             fi
           else
-            if [ "${BASE_BRANCH}" != "master" ]; then
-              echo "Repository has no develop branch; PRs must target master."
-              exit 1
+            if gh api "repos/${OWNER}/${REPO}/branches/develop" > /dev/null 2>&1; then
+              touch .github/develop-branch-marker
+              if [ "${BASE_BRANCH}" != "develop" ]; then
+                echo "Feature/fix/chore/etc branches must target develop when develop branch exists."
+                exit 1
+              fi
+            else
+              if [ "${BASE_BRANCH}" != "master" ]; then
+                echo "Repository has no develop branch; PRs must target master."
+                exit 1
+              fi
             fi
           fi
 

--- a/apps/maestros-del-salmon/Dockerfile
+++ b/apps/maestros-del-salmon/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npm run build --workspace=apps/maestros-del-salmon
+RUN npx turbo run build --filter=maestros-del-salmon
 RUN npm prune --omit=dev
 
 FROM node:20-alpine AS runner

--- a/apps/portfolio/Dockerfile
+++ b/apps/portfolio/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci
 
 COPY . .
 
-RUN npm run build --workspace=apps/portfolio
+RUN npx turbo run build --filter=portfolio
 RUN npm prune --omit=dev
 
 FROM node:20-alpine AS runner

--- a/openspec/changes/cicd-optimization/tasks.md
+++ b/openspec/changes/cicd-optimization/tasks.md
@@ -42,8 +42,8 @@ Chain strategy: stacked-to-main
 
 ## Phase 3: CD Refactoring (matrix + Docker caching)
 
-- [ ] 3.1 [GCP-01] Refactor `cd-cloudrun.yml`: replace `deploy-portfolio` and `deploy-maestros-del-salmon` jobs with single matrix `deploy` job using `matrix.app`. Parameterize `SERVICE_NAME`, `IMAGE_NAME`, `SMOKE_PATH`, secrets, env vars via `${{ matrix.app.* }}`. Verify: `act --matrix app=portfolio` runs without YAML errors. **GitHub issue required.**
-- [ ] 3.2 [GCP-02] Add Docker buildx layer caching to `cd-cloudrun.yml` build step: `--cache-from type=gha` and `--cache-to type=gha,mode=max`. Ensure buildx is configured (`docker buildx create --use` or existing builder). **GitHub issue required.**
-- [ ] 3.3 [GCP-03] Update `apps/portfolio/Dockerfile` and `apps/maestros-del-salmon/Dockerfile`: replace `RUN npm run build --workspace=apps/...` with `RUN npx turbo run build --filter=...`. **GitHub issue required.**
-- [ ] 3.4 [CSA-03] Add develop-branch check cache to `pr-governance.yml`: wrap `gh api branches/develop` call with `actions/cache@v4` keyed on a stable ref (e.g., `develop-branch-check-${{ github.sha }}`). **GitHub issue required.**
+- [x] 3.1 [GCP-01] Refactor `cd-cloudrun.yml`: replace `deploy-portfolio` and `deploy-maestros-del-salmon` jobs with single matrix `deploy` job using `matrix.app`. Parameterize `SERVICE_NAME`, `IMAGE_NAME`, `SMOKE_PATH`, secrets, env vars via `${{ matrix.app.* }}`. Verify: `act --matrix app=portfolio` runs without YAML errors. **GitHub issue required.**
+- [x] 3.2 [GCP-02] Add Docker buildx layer caching to `cd-cloudrun.yml` build step: `--cache-from type=gha` and `--cache-to type=gha,mode=max`. Ensure buildx is configured (`docker buildx create --use` or existing builder). **GitHub issue required.**
+- [x] 3.3 [GCP-03] Update `apps/portfolio/Dockerfile` and `apps/maestros-del-salmon/Dockerfile`: replace `RUN npm run build --workspace=apps/...` with `RUN npx turbo run build --filter=...`. **GitHub issue required.**
+- [x] 3.4 [CSA-03] Add develop-branch check cache to `pr-governance.yml`: wrap `gh api branches/develop` call with `actions/cache@v4` keyed on a stable ref (e.g., `develop-branch-check-${{ github.sha }}`). **GitHub issue required.**
 - [ ] 3.5 Verify Phase 3: push to master; confirm both Cloud Run services deploy identically. Verify Docker cache hits on subsequent deploys. Verify pr-governance cache behavior.


### PR DESCRIPTION
Closes #81

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary

- Refactor cd-cloudrun.yml to use matrix strategy, replacing two duplicate deploy jobs with a single parameterized `deploy` job
- Add Docker buildx caching (`--cache-from type=gha`, `--cache-to type=gha,mode=max`) for faster subsequent builds
- Update both Dockerfiles to use `npx turbo run build --filter=<app>` instead of `npm run build --workspace=...`
- Cache develop branch existence check in pr-governance.yml with `actions/cache@v4`

## Changes

| File | Change |
|------|--------|
| `.github/workflows/cd-cloudrun.yml` | Matrix deploy strategy with conditional env vars/secrets; buildx caching; act simulation preserved |
| `.github/workflows/pr-governance.yml` | Cache develop branch check with `actions/cache@v4`, skip API call on cache hit |
| `apps/portfolio/Dockerfile` | `npm run build --workspace=apps/portfolio` → `npx turbo run build --filter=portfolio` |
| `apps/maestros-del-salmon/Dockerfile` | `npm run build --workspace=apps/maestros-del-salmon` → `npx turbo run build --filter=maestros-del-salmon` |
| `openspec/changes/cicd-optimization/tasks.md` | Tasks 3.1–3.4 marked complete |

## Test Plan

- [x] YAML syntax validated for cd-cloudrun.yml and pr-governance.yml
- [ ] Cloud Run deploy can only be verified after merge to master (requires GCP secrets)
- [ ] Docker buildx cache requires a real GHA run to confirm cache hits
- [ ] pr-governance develop cache requires a real PR to verify

## Contributor Checklist

- [x] Linked an approved issue (#81)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers