### PR TITLE
fix(e2e): replace waitForLoadState with waitForURL for SPA navigation in Safari

### DIFF
--- a/apps/portfolio/e2e/project-grid-seo.spec.ts
+++ b/apps/portfolio/e2e/project-grid-seo.spec.ts
@@ -109,7 +109,10 @@ test.describe("Project Grid — SEO & Semantic HTML", () => {
     expect(href).toContain("/projects/");
 
     await projectLink.click();
-    await page.waitForLoadState("networkidle");
+
+    // Wait for URL to reflect SPA navigation (next/link client-side routing)
+    // waitForLoadState("networkidle") is unreliable in Safari/WebKit for SPA nav
+    await page.waitForURL("**/projects/**", { timeout: 15000 });
 
     // Should be on a project page
     expect(page.url()).toContain("/projects/");


### PR DESCRIPTION
Closes #85

## PR Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replace `waitForLoadState("networkidle")` with `waitForURL("**/projects/**", { timeout: 15000 })` in `project-grid-seo.spec.ts`
- `next/link` client-side navigation is not reliably detected by `waitForLoadState("networkidle")` in WebKit/Safari, causing the test to check the URL before SPA navigation completes

## Changes

| File | Change |
|------|--------|
| `apps/portfolio/e2e/project-grid-seo.spec.ts` | `waitForLoadState("networkidle")` → `waitForURL("**/projects/**")` at line 112 |

## Test Plan

- [x] Conventional commit format
- [ ] CI "WebKit + Reduced Motion" and "Desktop Chrome + Memory Leak" jobs should now pass the card navigation test
- [ ] No change to test assertions — only the wait strategy changed

## Contributor Checklist

- [x] Linked an approved issue (#85)
- [ ] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (none modified)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers