### PR TITLE
fix(lighthouse): audit /en instead of / to bypass middleware redirect

### DIFF
--- a/apps/portfolio/lighthouserc.cjs
+++ b/apps/portfolio/lighthouserc.cjs
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     collect: {
       numberOfRuns: 3,
-      url: ["http://127.0.0.1:4173/"],
+      url: ["http://127.0.0.1:4173/en"],
       startServerCommand: "npm run start -- --port 4173",
       startServerReadyPattern: "Ready",
       startServerReadyTimeout: 120000,

--- a/apps/portfolio/lighthouserc.cjs
+++ b/apps/portfolio/lighthouserc.cjs
@@ -8,6 +8,7 @@ module.exports = {
       startServerReadyTimeout: 120000,
       settings: {
         preset: "desktop",
+        chromeFlags: "--no-sandbox --disable-dev-shm-usage",
       },
     },
     assert: {


### PR DESCRIPTION
Closes #91

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Change Lighthouse CI audit URL from `/` to `/en` — bypasses next-intl middleware redirect
- Add `--no-sandbox --disable-dev-shm-usage` Chrome flags for CI runners
- Lower performance threshold from 0.90 to 0.65 (from PR #90, already merged)

**Note**: The `CHROME_INTERSTITIAL_ERROR` persists even after these changes. The root cause is that Chrome in lhci cannot start or connect on GitHub Actions runners. This is tracked separately in **#93**.

## Changes

| File | Change |
|------|--------|
| `apps/portfolio/lighthouserc.cjs` | URL `/` → `/en`, added Chrome CI flags, `minScore` 0.90 → 0.65 |

## Test Plan

- [x] Conventional commit format
- [x] All other CI checks pass (E2E, lint, typecheck, build)
- [ ] Lighthouse CI still shows `CHROME_INTERSTITIAL_ERROR` — tracked in #93
- [ ] Once #93 is fixed, these config changes will allow lhci to actually audit the page

## Contributor Checklist

- [x] Linked an approved issue (#91)
- [ ] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (none modified)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers