### PR TITLE
fix(ci): pr-governance.yml YAML parse error on every push to master

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -93,13 +93,13 @@ jobs:
           set -euo pipefail
           PR_BODY="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')"
           ISSUE_NUMBER="$(python - <<'PY'
-import os
-import re
-body = os.environ.get("PR_BODY", "")
-match = re.search(r'(?im)\b(closes|fixes|resolves)\s+#(\d+)\b', body)
-print(match.group(2) if match else "")
-PY
-)"
+          import os
+          import re
+          body = os.environ.get("PR_BODY", "")
+          match = re.search(r'(?im)\b(closes|fixes|resolves)\s+#(\d+)\b', body)
+          print(match.group(2) if match else "")
+          PY
+          )"
           if [ -z "${ISSUE_NUMBER}" ]; then
             echo "PR body must include: Closes #<issue>, Fixes #<issue>, or Resolves #<issue>"
             exit 1
@@ -132,13 +132,13 @@ PY
           set -euo pipefail
           PR_BODY="$(gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""')"
           SEMVER_COUNT="$(python - <<'PY'
-import os
-import re
-body = os.environ.get("PR_BODY", "")
-matches = re.findall(r'(?im)^-\s+\[[xX]\]\s+`semver:(patch|minor|major|none)`', body)
-print(len(matches))
-PY
-)"
+          import os
+          import re
+          body = os.environ.get("PR_BODY", "")
+          matches = re.findall(r'(?im)^-\s+\[[xX]\]\s+`semver:(patch|minor|major|none)`', body)
+          print(len(matches))
+          PY
+          )"
           if [ "${SEMVER_COUNT}" -ne 1 ]; then
             echo "PR template must select exactly one SemVer impact checkbox (`semver:patch|minor|major|none`). Found: ${SEMVER_COUNT}"
             exit 1


### PR DESCRIPTION
## Linked Issue
Closes #99

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix
- [ ] `semver:minor` - Backward-compatible feature
- [ ] `semver:major` - Breaking change
- [ ] `semver:none` - Docs/chore/no runtime impact

## Summary
- Indent Python heredoc bodies and `PY` terminator inside two `run: |` steps so the YAML block scalar parses cleanly. GitHub previously rejected the workflow on every push to master, producing a 0s failed run named after the file.

## Changes Table
| File | Change |
|------|--------|
| `.github/workflows/pr-governance.yml` | Indent Python heredoc bodies (`import os`, regex, prints) and `PY` terminators to 10 spaces in `Validate linked issue in PR body` and `Validate SemVer selection in PR template` steps. |

## Test Plan
- [x] Manually tested the affected functionality
- [x] Verified Sanity Studio data
- [x] Conventional commit format

Verification:
```
$ npx --yes js-yaml .github/workflows/pr-governance.yml > /dev/null && echo OK
OK
```
Also simulated the bash heredoc with an exported `PR_BODY="Closes #123"` — Python correctly emits `123`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests
- [x] Docs updated if needed
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention