### PR TITLE
fix(cd): use .Manifest.Digest for buildx imagetools inspect template

### DIFF
--- a/.github/workflows/cd-cloudrun.yml
+++ b/.github/workflows/cd-cloudrun.yml
@@ -118,7 +118,7 @@ jobs:
             -t "${IMAGE_LATEST}" \
             --push \
             .
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE_TAG}" --format '{{ .Digest }}')"
+          DIGEST="$(docker buildx imagetools inspect "${IMAGE_TAG}" --format '{{ .Manifest.Digest }}')"
           echo "IMAGE_DIGEST=${IMAGE_BASE}@${DIGEST}" >> "${GITHUB_ENV}"
 
       - name: Build image (act simulation)


### PR DESCRIPTION
## Linked Issue
Closes #102

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix
- [ ] `semver:minor` - Backward-compatible feature
- [ ] `semver:major` - Breaking change
- [ ] `semver:none` - Docs/chore/no runtime impact

## Summary
- Change `docker buildx imagetools inspect --format '{{ .Digest }}'` to `'{{ .Manifest.Digest }}'` so the digest extraction step in CD Cloud Run stops failing with `can't evaluate field Digest in type imagetools.tplInput`.

## Changes Table
| File | Change |
|------|--------|
| `.github/workflows/cd-cloudrun.yml` | Use `.Manifest.Digest` for buildx imagetools inspect template — image push already succeeds; only digest extraction was broken. |

## Test Plan
- [x] Manually tested the affected functionality
- [x] Conventional commit format

Verification trace from the failing run on master sha `66da5a5`:
```
ERROR: template: :1:3: executing "" at <.Digest>: can't evaluate field Digest in type imagetools.tplInput
```
After the fix, the template resolves to the manifest list digest produced by the same build (e.g. `sha256:01f5f2e1...` in run 25993214205 logs).

Per Docker's buildx imagetools inspect docs, the exposed top-level template fields are `.Name`, `.Manifest`, and `.Image` only — the digest is accessed via `.Manifest.Digest`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests
- [x] Docs updated if needed
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention