### PR TITLE
fix(ci): resolve buildx imagetools inspect template error

### DIFF
--- a/.github/workflows/cd-cloudrun.yml
+++ b/.github/workflows/cd-cloudrun.yml
@@ -111,6 +111,7 @@ jobs:
           IMAGE_TAG="${IMAGE_BASE}:${GITHUB_SHA}"
           IMAGE_LATEST="${IMAGE_BASE}:latest"
           docker buildx build \
+            --metadata-file metadata.json \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             -f "apps/${{ matrix.app.name }}/Dockerfile" \
@@ -118,7 +119,7 @@ jobs:
             -t "${IMAGE_LATEST}" \
             --push \
             .
-          DIGEST="$(docker buildx imagetools inspect "${IMAGE_TAG}" --format '{{ .Manifest.Digest }}')"
+          DIGEST="$(jq -r '."containerimage.digest"' metadata.json)"
           echo "IMAGE_DIGEST=${IMAGE_BASE}@${DIGEST}" >> "${GITHUB_ENV}"
 
       - name: Build image (act simulation)


### PR DESCRIPTION
Closes #110

- [x] `semver:patch`

Fixes the CD workflow failing at `Build and push image` with `can't evaluate field Digest in type imagetools.tplInput`. Uses `--metadata-file` instead of `imagetools inspect` to reliably parse the image digest.

| File | Change |
|------|--------|
| `.github/workflows/cd-cloudrun.yml` | Replace `imagetools inspect` with `--metadata-file` |

- [x] Scripts run without errors: `shellcheck scripts/*.sh`
- [x] Manually tested the affected functionality
- [x] Skills load correctly in target agent

- Linked an approved issue
- Added exactly one `type:*` label
- Ran shellcheck on modified scripts
- Skills tested in at least one agent
- Docs updated if behavior changed
- Conventional commit format
- No `Co-Authored-By` trailers
