### PR TITLE
fix(portfolio): center CommandNav on desktop (Tailwind v4 translate vs animation transform)

### DIFF
--- a/apps/portfolio/app/globals.css
+++ b/apps/portfolio/app/globals.css
@@ -333,13 +333,19 @@ body::before {
   }
 }
 
+/* On md+ the dock is centered via Tailwind's `md:-translate-x-1/2`, which
+ * Tailwind v4 compiles to the standalone CSS `translate:` property. Keep
+ * this keyframe limited to the Y axis so the animated `transform:` does
+ * NOT compose with the Tailwind `translate:` (composing would double-shift
+ * the element by -100% of its own width → right-aligned dock).
+ */
 @keyframes liquid-nav-rise-md {
   from {
-    transform: translate(-50%, 100px);
+    transform: translateY(100px);
     opacity: 0;
   }
   to {
-    transform: translate(-50%, 0);
+    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -355,8 +361,9 @@ body::before {
   .liquid-nav-root {
     animation-name: liquid-nav-rise-md;
   }
+  /* Y-only hide transform; X centering comes from Tailwind's `translate:`. */
   .liquid-nav-root[data-hidden="true"] {
-    transform: translate(-50%, 140px);
+    transform: translateY(140px);
     opacity: 0;
   }
 }
@@ -413,11 +420,10 @@ body.mobile-nav-open #hero .pointer-events-auto {
     transform: none !important;
     opacity: 1 !important;
   }
-  @media (min-width: 768px) {
-    .liquid-nav-root {
-      transform: translateX(-50%) !important;
-    }
-  }
+  /* No md+ override needed: Tailwind v4 emits `md:-translate-x-1/2` on the
+   * standalone `translate:` property, which is independent from `transform:`
+   * and survives the `transform: none !important` reset above.
+   */
 }
 
 /* ── CookieBanner — slide-in from bottom (post-framer-motion) ── */


### PR DESCRIPTION
## Linked Issue
Closes #112

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix
- [ ] `semver:minor` - Backward-compatible feature
- [ ] `semver:major` - Breaking change
- [ ] `semver:none` - Docs/chore/no runtime impact

## Summary
- Center the CommandNav (LiquidNav) dock on desktop again by removing the redundant `-50%` X translation from the CSS animation keyframe and the related hide/reduced-motion rules.
- Root cause: Tailwind v4 compiles `md:-translate-x-1/2` to the standalone CSS `translate:` property, while the keyframe `liquid-nav-rise-md` was animating `transform: translate(-50%, …)`. These are independent properties that compose multiplicatively per CSS Transforms Level 2 — the dock ended up shifted by -100% of its own width and rendered right-aligned at md+.
- Fix limits the animation/static rules to the Y axis and lets Tailwind's `translate:` own the X centering. The reduced-motion `@media (min-width: 768px)` override is no longer needed because `transform: none !important` does not affect the standalone `translate:` property.

## Changes Table
| File | Change |
|------|--------|
| `apps/portfolio/app/globals.css` | `liquid-nav-rise-md` keyframe and `[data-hidden="true"]` md+ rule switched from `transform: translate(-50%, …)` to `transform: translateY(…)`. Removed obsolete md+ override inside `prefers-reduced-motion: reduce`. Added explanatory comments. |

## Test Plan
- [x] Manually tested the affected functionality
- [x] Verified Sanity Studio data
- [x] Conventional commit format

### Verification steps
- Existing CommandNav suite passes: `npx turbo run test --filter=portfolio -- --run CommandNav` → 5/5 ✓.
- Local dev (`pnpm --filter portfolio dev`): dock renders centered at md+ viewports (verified via DevTools `getBoundingClientRect()` — `left + width/2 === innerWidth/2`).
- Reduced-motion (`prefers-reduced-motion: reduce`): dock still centered at md+ because Tailwind's `translate:` survives the `transform: none !important` reset.
- Mobile (<768px): full-width dock unchanged, animation `liquid-nav-rise` (no X translate) untouched.

## Contributor Checklist
- [x] Linked an approved issue (#112 has `status:approved`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests
- [x] Docs updated if needed (n/a — inline CSS comments added for context)
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention (`fix/commandnav-desktop-centering`)
