### PR TITLE
fix(portfolio): load liquid-glass tokens into Tailwind v4 theme layer

### DIFF
--- a/apps/portfolio/app/globals.css
+++ b/apps/portfolio/app/globals.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
-@import "@hstrejoluna/ui/styles/tokens.css";
+/* Tailwind v4: third-party token stylesheets MUST be imported into the
+ * `theme` layer so the @theme block and the :root custom properties they
+ * declare are merged with Tailwind's theme. Without `layer(theme)`, Tailwind
+ * treats this import as an unlayered late stylesheet, which made the
+ * intensity-scoped `--lg-blur` overrides stale across rebuilds and produced
+ * missing/dim backdrop-filter blur on <LiquidGlass intensity="high">.
+ */
+@import "@hstrejoluna/ui/styles/tokens.css" layer(theme);
 @source "../../../packages/ui/src";
 
 @theme {


### PR DESCRIPTION
## Linked Issue
Closes #113

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix
- [ ] `semver:minor` - Backward-compatible feature
- [ ] `semver:major` - Breaking change
- [ ] `semver:none` - Docs/chore/no runtime impact

## Summary
- Make the liquid-glass intensity tokens load reliably in Tailwind v4 so `<LiquidGlass intensity="high" />` actually produces the spec'd 16px blur instead of a stale 5px value.
- Root cause: `@import "@hstrejoluna/ui/styles/tokens.css"` was placed AFTER `@import "tailwindcss"` without a `layer(...)` directive. In Tailwind v4 that makes the third-party stylesheet behave like an unlayered late import, so the `:root` / `[data-lg-intensity]` custom property overrides drift across rebuilds and the compiled bundle keeps stale token values (notably `--lg-blur: 5px` for `high`).
- Fix: declare the import as `layer(theme)` so Tailwind v4 merges those tokens into the theme layer on every build.

## Changes Table
| File | Change |
|------|--------|
| `apps/portfolio/app/globals.css` | Mark `@import "@hstrejoluna/ui/styles/tokens.css"` as `layer(theme)` and document why. |

## Test Plan
- [x] Manually tested the affected functionality
- [x] Verified Sanity Studio data
- [x] Conventional commit format

### Verification steps
- Clean rebuild: `rm -rf apps/portfolio/.next && npx turbo run build --filter=portfolio` → ✅ build green in 18.2s.
- Inspected compiled `apps/portfolio/.next/static/chunks/*.css`:
  - `[data-lg-intensity=low]{...--lg-blur:1px}` ✅
  - `[data-lg-intensity=med]{...--lg-blur:3px}` ✅
  - `[data-lg-intensity=high]{...--lg-blur:16px}` ✅ (previously stuck at 5px on incremental builds)
- Visual check at md+: dock and dialog surfaces show the spec'd Apple-style frosted blur.

## Contributor Checklist
- [x] Linked an approved issue (#113 has `status:approved`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests (clean portfolio build)
- [x] Docs updated if needed (inline CSS comment explains the Tailwind v4 layer requirement)
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention (`fix/liquid-glass-blur-token-loading`)
