### PR TITLE
fix(portfolio): allow json payload in sync-certificates route

### DIFF
--- a/apps/portfolio/app/api/admin/sync-certificates/route.ts
+++ b/apps/portfolio/app/api/admin/sync-certificates/route.ts
@@ -3,6 +3,7 @@ import {
   buildDefaultSyncDeps,
   syncLinkedinCertificates,
 } from "@/lib/certificates/sync";
+import { normalizeCertificates } from "@/lib/certificates/normalize";
 
 const requiredEnv = [
   "APIFY_TOKEN",
@@ -36,10 +37,26 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await syncLinkedinCertificates(
-      linkedinProfileUrl,
-      buildDefaultSyncDeps(apifyToken)
-    );
+    const body = await request.json().catch(() => null);
+
+    let result;
+    if (body && Array.isArray(body) && body.length > 0) {
+      const { certificates, warnings } = normalizeCertificates({ certifications: body });
+      const deps = buildDefaultSyncDeps(apifyToken);
+      const upserted = await deps.repository.upsertMany(certificates);
+      
+      result = {
+        fetched: body.length,
+        upserted,
+        skipped: warnings.length,
+        warnings,
+      };
+    } else {
+      result = await syncLinkedinCertificates(
+        linkedinProfileUrl,
+        buildDefaultSyncDeps(apifyToken)
+      );
+    }
 
     return NextResponse.json(result, { status: 200 });
   } catch (error) {


### PR DESCRIPTION
## Linked Issue
Closes #120

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix
- [ ] `semver:minor` - Backward-compatible feature
- [ ] `semver:major` - Breaking change
- [ ] `semver:none` - Docs/chore/no runtime impact

## Summary
- Modified the `/api/admin/sync-certificates` route to parse incoming JSON.
- If an array is provided (simulating the Apify dataset export), it processes that array instead of calling the blocked Apify API.

## Changes Table
| File | Change |
|------|--------|
| `apps/portfolio/app/api/admin/sync-certificates/route.ts` | Added logic to accept a JSON array of certificates via the request body |

## Test Plan
- [x] Manually tested the affected functionality (the endpoint receives and parses the payload)
- [x] Verified Sanity Studio data (tested authorization layer)
- [x] Conventional commit format

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests
- [x] Docs updated if needed
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention