### PR TITLE
fix(portfolio): reduce project title font from text-6xl to text-4xl on mobile

### DIFF
--- a/apps/portfolio/app/[locale]/projects/[slug]/page.tsx
+++ b/apps/portfolio/app/[locale]/projects/[slug]/page.tsx
@@ -93,10 +93,7 @@ export async function generateMetadata({
 }: ProjectPageProps): Promise<Metadata> {
   const { locale, slug } = await params;
   const project = await getProject(slug);
-  const [tSeo, tCommon] = await Promise.all([
-    getTranslations({ locale, namespace: "seo" }),
-    getTranslations({ locale, namespace: "common" }),
-  ]);
+  const tCommon = await getTranslations({ locale, namespace: "common" });
 
   if (!project) return {};
 
@@ -234,7 +231,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
               }
               className="mb-8"
             />
-            <h1 className="text-6xl md:text-8xl font-black uppercase tracking-tighter italic leading-none mb-8">
+            <h1 className="text-4xl md:text-8xl font-black uppercase tracking-tighter italic leading-none mb-8">
               {project.title}
             </h1>
 


### PR DESCRIPTION
Closes #122

## PR Type
- [x] Bug fix

## Versioning Impact (SemVer)
- [x] `semver:patch` - Backward-compatible fix

## Summary
- Reduced project title `<h1>` font on mobile from `text-6xl` (60px) to `text-4xl` (36px)
- Removed unused `tSeo` translation fetch in `generateMetadata`
- Desktop font (`md:text-8xl` / 96px) unchanged

## Changes Table
| File | Change |
|------|--------|
| `apps/portfolio/app/[locale]/projects/[slug]/page.tsx` | `text-6xl` → `text-4xl` on `<h1>` (mobile); removed unused `tSeo` |

## Test Plan
- [x] Manually tested the affected functionality
- [x] Conventional commit format

## Contributor Checklist
- [x] Linked an approved issue (Closes #122)
- [x] Added exactly one `type:*` label
- [x] Selected exactly one `semver:*` checkbox above
- [x] Ran checks/tests
- [x] Conventional commit format
- [x] Branch name follows `type/description` convention